### PR TITLE
Renderer\Renderer.php Fix typo line 117 (maybe from copy/paste mistake)

### DIFF
--- a/Renderer/Renderer.php
+++ b/Renderer/Renderer.php
@@ -114,6 +114,6 @@ abstract class Renderer
      */
     public function setCharset($string)
     {
-        $this->renderCompressed = (string) $bool;
+        $this->charset = (string) $string;
     }
 }


### PR DESCRIPTION
Renderer\Renderer.php

Function setCharset() was defined:

$this->renderCompressed = (string) $bool;

but it should be:

$this->charset = (string) $string;
