### PR TITLE
Router factory

### DIFF
--- a/MenuFactory.php
+++ b/MenuFactory.php
@@ -15,7 +15,7 @@ class MenuFactory
      */
     public function createFromNode(NodeInterface $node)
     {
-        $item = new MenuItem($node->getName(), $node->getUri(), $node->getAttributes());
+        $item = new MenuItem($node->getName(), $this->getUriFromNode($node), $node->getAttributes());
         $item->setLabel($node->getLabel());
 
         foreach ($node->getChildren() as $childNode) {
@@ -42,5 +42,16 @@ class MenuFactory
         $menu->fromArray($data);
 
         return $menu;
+    }
+
+    /**
+     * Get the uri for the given node
+     *
+     * @param NodeInterface $node
+     * @return string
+     */
+    protected function getUriFromNode(NodeInterface $node)
+    {
+        return $node->getUri();
     }
 }

--- a/Router/RouterMenuFactory.php
+++ b/Router/RouterMenuFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Knplabs\MenuBundle\Router;
+
+use Knplabs\MenuBundle\MenuFactory;
+use Knplabs\MenuBundle\NodeInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Factory to create a menu from a tree
+ */
+class RouterMenuFactory extends MenuFactory
+{
+    /**
+     * @var Symfony\Component\Routing\RouterInterface
+     */
+    protected $router;
+
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUriFromNode(NodeInterface $node)
+    {
+        if ($node instanceof RouterNodeInterface && null !== $node->getRoute()) {
+            return $this->router->generate($node->getRoute(), $node->getRouteParameters(), $node->isRouteAbsolute());
+        }
+
+        return $node->getUri();
+    }
+}

--- a/Router/RouterNodeInterface.php
+++ b/Router/RouterNodeInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Knplabs\MenuBundle\Router;
+
+use Knplabs\MenuBundle\NodeInterface;
+
+/**
+ * Interface implemented by a node to construct a menu from a tree.
+ */
+interface RouterNodeInterface extends NodeInterface
+{
+    /**
+     * Get the route of the link
+     *
+     * If this method returns null, getUri() will be used.
+     * If both a route and an uri are provided, the route is used.
+     *
+     * @return string
+     */
+    function getRoute();
+
+    /**
+     * Get the parameters used to generate the route
+     *
+     * @return array
+     */
+    function getRouteParameters();
+
+    /**
+     * Whether the generated uri should be absolute
+     *
+     * @return boolean
+     */
+    function isRouteAbsolute();
+}


### PR DESCRIPTION
This adds a router aware factory to allow Symfony2 users to specify a route instead of an url when creating the menu from a tree structure (needed as an entity cannot be router aware to generate the route itself).

An improvement could be to define this factory as a service to pass it the router but I don"t see a good way to handle this to avoid loading the definition twice if someone uses both `menu.twig` and `menu.templating` (and semantically it should perhaps be a third one)
