### PR TITLE
Added support for links and non-links attributes and no link rendering for current item

### DIFF
--- a/MenuItem.php
+++ b/MenuItem.php
@@ -18,6 +18,8 @@ class MenuItem implements \ArrayAccess, \Countable, \IteratorAggregate
     protected
         $name             = null,    // the name of this menu item (used for id by parent menu)
         $label            = null,    // the label to output, name is used by default
+        $linkAttributes   = array(), // an array of attributes for the item link
+        $labelAttributes  = array(), // an array of attributes for the item text
         $uri              = null,    // the uri to use in the anchor tag
         $attributes       = array(); // an array of attributes for the li
 
@@ -36,7 +38,8 @@ class MenuItem implements \ArrayAccess, \Countable, \IteratorAggregate
         $num              = null,    // the order number this menu is in its parent
         $parent           = null,    // parent MenuItem
         $isCurrent        = null,    // whether or not this menu item is current
-        $currentUri       = null;    // the current uri to use for selecting current menu
+        $currentUri       = null,    // the current uri to use for selecting current menu
+        $currentAsLink    = true;    // boolean to render the current uri as a link or not
 
     /**
      * The renderer used to render this menu
@@ -201,6 +204,94 @@ class MenuItem implements \ArrayAccess, \Countable, \IteratorAggregate
 
         return $this;
     }
+    
+    /**
+     * @return array
+     */
+    public function getLinkAttributes()
+    {
+        return $this->linkAttributes;
+    }
+
+    /**
+     * @param  array $linkAttributes
+     * @return MenuItem
+     */
+    public function setLinkAttributes(array $linkAttributes)
+    {
+        $this->linkAttributes = $linkAttributes;
+
+        return $this;
+    }
+
+    /**
+     * @param  string $name     The name of the attribute to return
+     * @param  mixed  $default  The value to return if the attribute doesn't exist
+     *
+     * @return mixed
+     */
+    public function getLinkAttribute($name, $default = null)
+    {
+        if (isset($this->linkAttributes[$name])) {
+            return $this->linkAttributes[$name];
+        }
+
+        return $default;
+    }
+
+    /**
+     * @param string $name
+     * @param string $value
+     * 
+     * @return MenuItem 
+     */   
+    public function setLinkAttribute($name, $value)
+    {
+        $this->linkAttributes[$name] = $value;
+
+        return $this;
+    }  
+    
+    /**
+     * @return array
+     */
+    public function getLabelAttributes()
+    {
+        return $this->labelAttributes;
+    }
+
+    /**
+     * @param  array $labelAttributes
+     * @return MenuItem
+     */
+    public function setLabelAttributes(array $labelAttributes)
+    {
+        $this->labelAttributes = $labelAttributes;
+
+        return $this;
+    }
+
+    /**
+     * @param  string $name     The name of the attribute to return
+     * @param  mixed  $default  The value to return if the attribute doesn't exist
+     *
+     * @return mixed
+     */
+    public function getLabelAttribute($name, $default = null)
+    {
+        if (isset($this->labelAttributes[$name])) {
+            return $this->labelAttributes[$name];
+        }
+
+        return $default;
+    }
+
+    public function setLabelAttribute($name, $value)
+    {
+        $this->labelAttributes[$name] = $value;
+
+        return $this;
+    }  
 
     /**
      * @return bool Whether or not this menu item should show its children.
@@ -1041,6 +1132,30 @@ class MenuItem implements \ArrayAccess, \Countable, \IteratorAggregate
             $child->setCurrentUri($uri);
         }
     }
+    
+    /**
+     * Sets if the current item should render a link or not
+     * 
+     * @param bool $currentAsLink 
+     */
+    public function setCurrentAsLink($currentAsLink = true)
+    {
+        $this->currentAsLink = (bool)$currentAsLink;
+    }
+    
+    /**
+     * Returns the currentAsLink
+     * 
+     * Used to determine if the current item must render
+     * its text as a link or not
+     * 
+     * @return bool
+     */
+    public function getCurrentAsLink()
+    {
+        return $this->currentAsLink;
+    }
+    
 
     /**
      * Calls a method recursively on all of the children of this item

--- a/Renderer/ListRenderer.php
+++ b/Renderer/ListRenderer.php
@@ -115,8 +115,9 @@ class ListRenderer extends Renderer implements RendererInterface
         // opening li tag
         $html = $this->format('<li'.$this->renderHtmlAttributes($attributes).'>', 'li', $item->getLevel());
 
-        // render the text/link inside the li tag
-        $html .= $this->format($item->getUri() ? $item->renderLink() : $item->renderLabel(), 'link', $item->getLevel());
+        // render the text/link inside the li tag        
+        //$html .= $this->format($item->getUri() ? $item->renderLink() : $item->renderLabel(), 'link', $item->getLevel());
+        $html .= $this->renderLink($item);
 
         // renders the embedded ul if there are visible children
         $html .= $this->doRender($item, $depth, true);
@@ -125,6 +126,36 @@ class ListRenderer extends Renderer implements RendererInterface
         $html .= $this->format('</li>', 'li', $item->getLevel());
 
         return $html;
+    }
+    
+    /**
+     * Renders the link in a a tag with link attributes or
+     * the label in a span tag with label attributes
+     *      
+     * Tests if item has a an uri and if not tests if it's
+     * the current item and if the text has to be rendered
+     * as a link or not.
+     *
+     * @param MenuItem $item The item to render the link or label for
+     * @return string
+     */
+    public function renderLink($item)
+    {        
+        $text = '';
+        if (!$item->getUri()) {
+            $text = sprintf('<span%s>%s</span>', $this->renderHtmlAttributes($item->getLabelAttributes()), $item->getLabel());
+        }   
+        else {            
+            if (($item->getIsCurrent() && $item->getParent()->getCurrentAsLink())                
+                || !$item->getIsCurrent()) {                
+                $text = sprintf('<a href="%s"%s>%s</a>', $item->getUri(), $this->renderHtmlAttributes($item->getLinkAttributes()), $item->getLabel());
+            }
+            else {                
+                $text = sprintf('<span%s>%s</span>', $this->renderHtmlAttributes($item->getLabelAttributes()), $item->getLabel());
+            }
+        }
+
+        return $this->format($text, 'link', $item->getLevel());
     }
 
     /**

--- a/Tests/MenuItemGetterSetterTest.php
+++ b/Tests/MenuItemGetterSetterTest.php
@@ -25,6 +25,13 @@ class MenuItemGetterSetterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($title, $menu->getAttribute('title'));
     }
 
+    public function testCurrentAsLink()
+    {
+        $menu = $this->createMenu();
+        $menu->setCurrentAsLink(true);
+        $this->assertEquals(true, $menu->getCurrentAsLink());
+    }
+    
     public function testName()
     {
         $menu = $this->createMenu();
@@ -59,6 +66,22 @@ class MenuItemGetterSetterTest extends \PHPUnit_Framework_TestCase
         $menu = $this->createMenu(null, null, array('id' => 'test_id'));
         $this->assertEquals('test_id', $menu->getAttribute('id'));
         $this->assertEquals('default_value', $menu->getAttribute('unknown_attribute', 'default_value'));
+    }
+    
+    public function testLinkAttributes()
+    {
+        $attributes = array('class' => 'test_class', 'title' => 'Test title');
+        $menu = $this->createMenu();
+        $menu->setLinkAttributes($attributes);
+        $this->assertEquals($attributes, $menu->getLinkAttributes());
+    }
+    
+    public function testLabelAttributes()
+    {
+        $attributes = array('class' => 'test_class', 'title' => 'Test title');
+        $menu = $this->createMenu();
+        $menu->setLabelAttributes($attributes);
+        $this->assertEquals($attributes, $menu->getLabelAttributes());
     }
 
     public function testShow()

--- a/Tests/MenuItemRenderTest.php
+++ b/Tests/MenuItemRenderTest.php
@@ -18,7 +18,7 @@ class MenuItemRenderTest extends \PHPUnit_Framework_TestCase
         $menu = new MenuItem('test', null, array('class' => 'test_class'));
         $menu->getRenderer()->setRenderCompressed(true);
         $menu->addChild('c1');
-        $rendered = '<ul class="test_class"><li class="first last">c1</li></ul>';
+        $rendered = '<ul class="test_class"><li class="first last"><span>c1</span></li></ul>';
         $this->assertEquals($rendered, $menu->render());
     }
 
@@ -27,7 +27,7 @@ class MenuItemRenderTest extends \PHPUnit_Framework_TestCase
         $menu = new MenuItem('test', null, array('title' => 'encode " me >'));
         $menu->getRenderer()->setRenderCompressed(true);
         $menu->addChild('c1');
-        $rendered = '<ul title="encode &quot; me &gt;"><li class="first last">c1</li></ul>';
+        $rendered = '<ul title="encode &quot; me &gt;"><li class="first last"><span>c1</span></li></ul>';
         $this->assertEquals($rendered, $menu->render());
     }
 
@@ -40,6 +40,16 @@ class MenuItemRenderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($rendered, $about->renderLink());
 
         $rendered = '<li class="last"><a href="/about">About</a></li>';
+        $this->assertEquals($rendered, $menu->getRenderer()->renderItem($about));
+    }
+    
+    public function testRenderLinkWithAttributes()
+    {
+        extract($this->getSampleTree());
+        $about = $menu->addChild('About', '/about');
+        $about->setLinkAttribute('title', 'About page');
+        
+        $rendered = '<li class="last"><a href="/about" title="About page">About</a></li>';
         $this->assertEquals($rendered, $menu->getRenderer()->renderItem($about));
     }
 
@@ -58,14 +68,14 @@ class MenuItemRenderTest extends \PHPUnit_Framework_TestCase
     public function testRenderWholeMenu()
     {
         extract($this->getSampleTree());
-        $rendered = '<ul class="root"><li class="first">Parent 1<ul class="menu_level_1"><li class="first">Child 1</li><li>Child 2</li><li class="last">Child 3</li></ul></li><li class="last">Parent 2<ul class="menu_level_1"><li class="first last">Child 4<ul class="menu_level_2"><li class="first last">Grandchild 1</li></ul></li></ul></li></ul>';
+        $rendered = '<ul class="root"><li class="first"><span>Parent 1</span><ul class="menu_level_1"><li class="first"><span>Child 1</span></li><li><span>Child 2</span></li><li class="last"><span>Child 3</span></li></ul></li><li class="last"><span>Parent 2</span><ul class="menu_level_1"><li class="first last"><span>Child 4</span><ul class="menu_level_2"><li class="first last"><span>Grandchild 1</span></li></ul></li></ul></li></ul>';
         $this->assertEquals($rendered, $menu->render());
     }
 
     public function testToString()
     {
         extract($this->getSampleTree());
-        $rendered = '<ul class="root"><li class="first">Parent 1<ul class="menu_level_1"><li class="first">Child 1</li><li>Child 2</li><li class="last">Child 3</li></ul></li><li class="last">Parent 2<ul class="menu_level_1"><li class="first last">Child 4<ul class="menu_level_2"><li class="first last">Grandchild 1</li></ul></li></ul></li></ul>';
+        $rendered = '<ul class="root"><li class="first"><span>Parent 1</span><ul class="menu_level_1"><li class="first"><span>Child 1</span></li><li><span>Child 2</span></li><li class="last"><span>Child 3</span></li></ul></li><li class="last"><span>Parent 2</span><ul class="menu_level_1"><li class="first last"><span>Child 4</span><ul class="menu_level_2"><li class="first last"><span>Grandchild 1</span></li></ul></li></ul></li></ul>';
         $this->assertEquals($rendered, (string) $menu);
     }
 
@@ -74,7 +84,7 @@ class MenuItemRenderTest extends \PHPUnit_Framework_TestCase
         extract($this->getSampleTree());
         $pt2->setAttribute('class', 'parent2_class');
         $pt2->setAttribute('title', 'parent2 title');
-        $rendered = '<ul class="root"><li class="first">Parent 1<ul class="menu_level_1"><li class="first">Child 1</li><li>Child 2</li><li class="last">Child 3</li></ul></li><li class="parent2_class last" title="parent2 title">Parent 2<ul class="menu_level_1"><li class="first last">Child 4<ul class="menu_level_2"><li class="first last">Grandchild 1</li></ul></li></ul></li></ul>';
+        $rendered = '<ul class="root"><li class="first"><span>Parent 1</span><ul class="menu_level_1"><li class="first"><span>Child 1</span></li><li><span>Child 2</span></li><li class="last"><span>Child 3</span></li></ul></li><li class="parent2_class last" title="parent2 title"><span>Parent 2</span><ul class="menu_level_1"><li class="first last"><span>Child 4</span><ul class="menu_level_2"><li class="first last"><span>Grandchild 1</span></li></ul></li></ul></li></ul>';
         $this->assertEquals($rendered, $menu->render());
     }
 
@@ -82,8 +92,30 @@ class MenuItemRenderTest extends \PHPUnit_Framework_TestCase
     {
         extract($this->getSampleTree());
         $ch2->setIsCurrent(true);
-        $rendered = '<ul class="root"><li class="current_ancestor first">Parent 1<ul class="menu_level_1"><li class="first">Child 1</li><li class="current">Child 2</li><li class="last">Child 3</li></ul></li><li class="last">Parent 2<ul class="menu_level_1"><li class="first last">Child 4<ul class="menu_level_2"><li class="first last">Grandchild 1</li></ul></li></ul></li></ul>';
+        $rendered = '<ul class="root"><li class="current_ancestor first"><span>Parent 1</span><ul class="menu_level_1"><li class="first"><span>Child 1</span></li><li class="current"><span>Child 2</span></li><li class="last"><span>Child 3</span></li></ul></li><li class="last"><span>Parent 2</span><ul class="menu_level_1"><li class="first last"><span>Child 4</span><ul class="menu_level_2"><li class="first last"><span>Grandchild 1</span></li></ul></li></ul></li></ul>';
         $this->assertEquals($rendered, $menu->render());
+    }
+    
+    public function testRenderWithCurrentItemAsLink()
+    {
+        extract($this->getSampleTree());
+        $about = $menu->addChild('About', '/about');
+        $about->setIsCurrent(true);
+        $menu->setCurrentAsLink(true);
+        
+        $rendered = '<li class="current last"><a href="/about">About</a></li>';
+        $this->assertEquals($rendered, $menu->getRenderer()->renderItem($about));
+    }
+    
+    public function testRenderWithCurrentItemNotAsLink()
+    {
+        extract($this->getSampleTree());
+        $about = $menu->addChild('About', '/about');
+        $about->setIsCurrent(true);
+        $menu->setCurrentAsLink(false);
+        
+        $rendered = '<li class="current last"><span>About</span></li>';
+        $this->assertEquals($rendered, $menu->getRenderer()->renderItem($about));
     }
 
     public function testRenderSubMenuPortionWithClassAndTitle()
@@ -91,7 +123,7 @@ class MenuItemRenderTest extends \PHPUnit_Framework_TestCase
         extract($this->getSampleTree());
         $pt2->setAttribute('class', 'parent2_class');
         $pt2->setAttribute('title', 'parent2 title');
-        $rendered = '<ul class="parent2_class" title="parent2 title"><li class="first last">Child 4<ul class="menu_level_2"><li class="first last">Grandchild 1</li></ul></li></ul>';
+        $rendered = '<ul class="parent2_class" title="parent2 title"><li class="first last"><span>Child 4</span><ul class="menu_level_2"><li class="first last"><span>Grandchild 1</span></li></ul></li></ul>';
         $this->assertEquals($rendered, $menu['Parent 2']->render());
     }
 
@@ -107,7 +139,7 @@ class MenuItemRenderTest extends \PHPUnit_Framework_TestCase
     {
         extract($this->getSampleTree());
         $menu['Parent 1']->setShowChildren(false);
-        $rendered = '<ul class="root"><li class="first">Parent 1</li><li class="last">Parent 2<ul class="menu_level_1"><li class="first last">Child 4<ul class="menu_level_2"><li class="first last">Grandchild 1</li></ul></li></ul></li></ul>';
+        $rendered = '<ul class="root"><li class="first"><span>Parent 1</span></li><li class="last"><span>Parent 2</span><ul class="menu_level_1"><li class="first last"><span>Child 4</span><ul class="menu_level_2"><li class="first last"><span>Grandchild 1</span></li></ul></li></ul></li></ul>';
         $this->assertEquals($rendered, $menu->render());
     }
 
@@ -115,7 +147,7 @@ class MenuItemRenderTest extends \PHPUnit_Framework_TestCase
     {
         extract($this->getSampleTree());
         $menu['Parent 1']->setShow(false);
-        $rendered = '<ul class="root"><li class="first last">Parent 2<ul class="menu_level_1"><li class="first last">Child 4<ul class="menu_level_2"><li class="first last">Grandchild 1</li></ul></li></ul></li></ul>';
+        $rendered = '<ul class="root"><li class="first last"><span>Parent 2</span><ul class="menu_level_1"><li class="first last"><span>Child 4</span><ul class="menu_level_2"><li class="first last"><span>Grandchild 1</span></li></ul></li></ul></li></ul>';
         $this->assertEquals($rendered, $menu->render());
     }
 
@@ -129,14 +161,14 @@ class MenuItemRenderTest extends \PHPUnit_Framework_TestCase
     public function testDepth1()
     {
         extract($this->getSampleTree());
-        $rendered = '<ul class="root"><li class="first">Parent 1</li><li class="last">Parent 2</li></ul>';
+        $rendered = '<ul class="root"><li class="first"><span>Parent 1</span></li><li class="last"><span>Parent 2</span></li></ul>';
         $this->assertEquals($rendered, $menu->render(1));
     }
 
     public function testDepth2()
     {
         extract($this->getSampleTree());
-        $rendered = '<ul class="root"><li class="first">Parent 1<ul class="menu_level_1"><li class="first">Child 1</li><li>Child 2</li><li class="last">Child 3</li></ul></li><li class="last">Parent 2<ul class="menu_level_1"><li class="first last">Child 4</li></ul></li></ul>';
+        $rendered = '<ul class="root"><li class="first"><span>Parent 1</span><ul class="menu_level_1"><li class="first"><span>Child 1</span></li><li><span>Child 2</span></li><li class="last"><span>Child 3</span></li></ul></li><li class="last"><span>Parent 2</span><ul class="menu_level_1"><li class="first last"><span>Child 4</span></li></ul></li></ul>';
         $this->assertEquals($rendered, $menu->render(2));
     }
 
@@ -144,7 +176,7 @@ class MenuItemRenderTest extends \PHPUnit_Framework_TestCase
     {
         extract($this->getSampleTree());
         $menu['Parent 1']->setShowChildren(false);
-        $rendered = '<ul class="root"><li class="first">Parent 1</li><li class="last">Parent 2<ul class="menu_level_1"><li class="first last">Child 4</li></ul></li></ul>';
+        $rendered = '<ul class="root"><li class="first"><span>Parent 1</span></li><li class="last"><span>Parent 2</span><ul class="menu_level_1"><li class="first last"><span>Child 4</span></li></ul></li></ul>';
         $this->assertEquals($rendered, $menu->render(2));
     }
 
@@ -173,7 +205,7 @@ class MenuItemRenderTest extends \PHPUnit_Framework_TestCase
         $arr = array_keys($menu->getChildren());
         $this->assertEquals(array('c4', 'c3', 'c2', 'c1'), $arr);
 
-        $this->assertEquals('<ul><li class="first">c4</li><li>c3</li><li>c2</li><li class="last">c1</li></ul>', $menu->render());
+        $this->assertEquals('<ul><li class="first"><span>c4</span></li><li><span>c3</span></li><li><span>c2</span></li><li class="last"><span>c1</span></li></ul>', $menu->render());
     }
 
     /**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
          processIsolation="true"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="../../../autoload.php"
+         bootstrap="../../../app/bootstrap.php"
 >
 
 <!--


### PR DESCRIPTION
c/c of the commit note :

1/ Added the possibility to set attributes for link tags and non-link ones (a span tag is used in that case)
2/ Added a MenuItem option setCurrentAsLink (default to true) to decide whether the current item should be rendered as a link or not
3/ Updated phpunit.xml.dist for the new "app/bootstrap.php" file
4/ Added unit tests for 1/ and 2/
5/ Updated unit tests for the new <span> tag for non-link items

Use case for 1/ and 2/ :
Each link can have its own :hover css transformation and need an id to be able to do that.
For SEO, the current item can be rendered without a link.

Code :

```
$this->setCurrentUri($request->getRequestUri());
$this->setAttribute('class', 'menu');
$this->setCurrentAsLink(false);

$this->addChild($translator->trans('menu.home'), $router->generate('home', array()))
     ->setLinkAttribute('id', 'home');

$this->addChild($translator->trans('menu.company'), $router->generate('company', array()))
     ->setLinkAttribute('id', 'company');
```

Also, since there is a class responsible for the rendering, the MenuItem should not render link and label html itself.

This commit makes MenuItem::renderLink() and MenuItem::renderLabel() obsoletes (and the corresponding tests too).
