### PR TITLE
Changed Dependency Injection definitions in provider.xml to match new schema locations (symfony.com instead of symfony-project.org)

### DIFF
--- a/Resources/config/provider.xml
+++ b/Resources/config/provider.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 
-<container xmlns="http://www.symfony-project.org/schema/dic/services"
+<container xmlns="http://symfony.com/schema/dic/services"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.symfony-project.org/schema/dic/services http://www.symfony-project.org/schema/dic/services/services-1.0.xsd">
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
         <parameter key="menu.provider.class">Knplabs\MenuBundle\Provider\LazyProvider</parameter>


### PR DESCRIPTION
In latest changes in symfony core, the schemas path changed from symfony-project.org to symfony.com and current MenuBundle fails with xsd validation - I fixed it in this commit.
