### PR TITLE
Changed called method name from getByPath to get

### DIFF
--- a/Templating/Helper/MenuHelper.php
+++ b/Templating/Helper/MenuHelper.php
@@ -26,7 +26,7 @@ class MenuHelper extends TemplatingHelper
      */
     public function get($menu, array $path = array())
     {
-        return $this->helper->getByPath($menu, $path);
+        return $this->helper->get($menu, $path);
     }
 
     /**


### PR DESCRIPTION
In KnpMenu helper method getByPath was merged with get method: https://github.com/KnpLabs/KnpMenu/commit/b9f05cb4f4ca8f54a30e3bc05a60a9f510f6e095#L0L52
KnpMenuBundle used getByPath, so I changed it. Please verify.
