### PR TITLE
Fix typo

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -80,7 +80,7 @@ public function registerBundles()
         new Knp\Bundle\MenuBundle\KnpMenuBundle(),
     );
     // ...
-)
+}
 ```
 
 ### Step 4) (optional) Configure the bundle


### PR DESCRIPTION
`)` instead of `}`
