### PR TITLE
Fixed incorrect documentation

### DIFF
--- a/Resources/doc/i18n.md
+++ b/Resources/doc/i18n.md
@@ -52,14 +52,15 @@ $menu->addChild('Home', array('route' => 'homepage'));
 $menu->addChild('Login', array('route' => 'login'));
 ```
 
-To translate them you need to add translation_domain parameter using addExtras:
+To specify a translation file you can optionally add the translation_domain parameter using setExtra.
+Otherwise, default is {BundleMenuIsRenderedIn}/Resources/translations/message.{locale}.yml
 
 ```php
 <?php
 $menu = $factory->createItem('root');
 
 // will look for "Home" in Acme/DemoBundle/Resources/translations/AcmeDemoBundle.locale.yml
-$menu->addChild('Home', array('route' => 'homepage'))->addExtra('translation_domain', 'AcmeDemoBundle'); 
+$menu->addChild('Home', array('route' => 'homepage'))->setExtra('translation_domain', 'messages'); 
 // will look for "Login" in Acme/AdminBundle/Resources/translations/AcmeAdminBundle.locale.yml      
-$menu->addChild('Login', array('route' => 'login'))->addExtra('translation_domain', 'AcmeLoginBundle');
+$menu->addChild('Login', array('route' => 'login'))->setExtra('translation_domain', 'AcmeLoginBundle');
 ```


### PR DESCRIPTION
To add a translation domain you must use `Knp\Menu\MenuItem::setExtra`, `addExtra` does not exist. 

Also, translation domain is not required, it will default to message.locale.yml
