### PR TITLE
charset as first argument in ListRenderer

### DIFF
--- a/Resources/config/menu.xml
+++ b/Resources/config/menu.xml
@@ -48,7 +48,6 @@
 
         <service id="knp_menu.renderer.list" class="%knp_menu.renderer.list.class%">
             <tag name="knp_menu.renderer" alias="list" />
-            <argument>%knp_menu.renderer.list.options%</argument>
             <argument>%kernel.charset%</argument>
         </service>
     </services>


### PR DESCRIPTION
AFAIK this DI configuration is wrong. It shows an error in SonataMediaBundle when you try to edit a media.
The problem is that the Renderer class constructor (parent of ListRenderer) is

```
/**
 * @param string $charset
 * @param boolean $renderCompressed
 */
public function __construct($charset = null, $renderCompressed = false)
```

so, giving this DIC configuration you got array() as charset. And it throws an error like:

```
An exception has been thrown during the rendering of a template ("Warning: htmlspecialchars() [<a href='function.htmlspecialchars'>function.htmlspecialchars</a>]: charset `Array' not supported, assuming 
iso-8859-1
```

The only thing I don't know is where the %knp_menu.renderer.list.options% parameter should be injected. But at least removing it solves the problem. Is this parameter still needed?

Regards.
