### PR TITLE
Typo in a requirement of the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require":      {
-        "knplabs/knp-menu":         "2.0.*",
+        "knplabs/knp-menu":         "2.0.*@dev",
         "symfony/framework-bundle": ">=2.0,<2.3-dev"
     },
     "autoload":     {


### PR DESCRIPTION
That composer.json threw a "no matching package found" error.
Should be fixed now.
