### PR TITLE
Changed Version constrained for symfony/master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require":      {
         "knplabs/knp-menu":         "2.0.*",
-        "symfony/framework-bundle": ">=2.0,<2.3-dev"
+        "symfony/framework-bundle": ">=2.0,<=2.3-dev"
     },
     "autoload":     {
         "psr-0": { "Knp\\Bundle\\MenuBundle": "" }


### PR DESCRIPTION
The current version works for me perfect with master (2.3.*) of symfony/symfony so i upgraded version constraint to be abled to install MenuBundle with composer
