### PR TITLE
Declaring namespaces in the Symfony >=2.1 way

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -69,12 +69,8 @@ in your autoloader:
 ``` php
 <?php
 // app/autoload.php
-$loader->registerNamespaces(array(
-    // ...
-    'Knp\Bundle' => __DIR__.'/../vendor/bundles',
-    'Knp\Menu'   => __DIR__.'/../vendor/KnpMenu/src',
-    // ...
-));
+$loader->add('Knp\Bundle', __DIR__.'/../vendor/bundles');
+$loader->add('Knp\Menu', __DIR__.'/../vendor/KnpMenu/src');
 ```
 
 ### Step 3) Register the bundle


### PR DESCRIPTION
I think the installation documentation should be updated.

``` php
<?php
// app/autoload.php
$loader->registerNamespaces(array(
    // ...
    'Knp\Bundle' => __DIR__.'/../vendor/bundles',
    'Knp\Menu'   => __DIR__.'/../vendor/KnpMenu/src',
    // ...
));
```

This seems to be the Symfony 2.0 way of declaring namespaces. Now we should have

``` php
<?php
// intl
if (!function_exists('intl_get_error_code')) {
    $loader->add('Knp\Bundle', __DIR__.'/../vendor/bundles');
    $loader->add('Knp\Menu', __DIR__.'/../vendor/KnpMenu/src');
    // … other declarations
}
```

My 2 cents

Guillaume
