### PR TITLE
Update index.md

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -34,7 +34,8 @@ Add on composer.json (see http://getcomposer.org/)
 
     "require" :  {
         // ...
-        "knplabs/knp-menu-bundle":"dev-master",
+        "knplabs/knp-menu":"dev-master",
+        "knplabs/knp-menu-bundle":"dev-master"
     }
 
 #### Method b) Using the `deps` file (symfony 2.0 pattern)


### PR DESCRIPTION
Composer's minimum-stability resulted in a not-found dependency for KnpMenu. Until KnpMenuBundle and KnpMenu are stable, I propose to explicitly specify the dev dependency in composer.json.

Referring to issue #195.
