### PR TITLE
"Build Menu"-event

### DIFF
--- a/DependencyInjection/Compiler/AddProvidersPass.php
+++ b/DependencyInjection/Compiler/AddProvidersPass.php
@@ -3,6 +3,8 @@ namespace Knp\Bundle\MenuBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -20,7 +22,10 @@ class AddProvidersPass implements CompilerPassInterface
 
         $providers = array();
         foreach ($container->findTaggedServiceIds('knp_menu.provider') as $id => $tags) {
-            $providers[] = new Reference($id);
+            $provider = new DefinitionDecorator('knp_menu.menu_provider.event_emitter');
+            $provider->replaceArgument(0, new Reference($id));
+
+            $providers[] = $provider;
         }
 
         if (1 === count($providers)) {

--- a/Event/ConfigureMenuEvent.php
+++ b/Event/ConfigureMenuEvent.php
@@ -1,0 +1,44 @@
+<?php
+namespace Knp\Bundle\MenuBundle\Event;
+
+use Knp\Menu\Provider\MenuProviderInterface;
+use Symfony\Component\EventDispatcher\Event;
+use Knp\Menu\ItemInterface;
+
+class ConfigureMenuEvent extends Event
+{
+    protected $builderName;
+    protected $provider;
+    protected $menu;
+
+    public function __construct (MenuProviderInterface $provider, ItemInterface $menu, $builderName)
+    {
+        $this->builderName = $builderName;
+        $this->provider = $provider;
+        $this->menu = $menu;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBuilderName()
+    {
+        return $this->builderName;
+    }
+
+    /**
+     * @return MenuProviderInterface
+     */
+    public function getProvider()
+    {
+        return $this->provider;
+    }
+
+    /**
+     * @return ItemInterface
+     */
+    public function getMenu()
+    {
+        return $this->menu;
+    }
+}

--- a/Events.php
+++ b/Events.php
@@ -1,0 +1,7 @@
+<?php
+namespace Knp\Bundle\MenuBundle;
+
+final class Events
+{
+    const CONFIGURE = 'knp_menu.menu_configure';
+}

--- a/Provider/EventEmittingProvider.php
+++ b/Provider/EventEmittingProvider.php
@@ -1,0 +1,49 @@
+<?php
+namespace Knp\Bundle\MenuBundle\Provider;
+
+use Knp\Bundle\MenuBundle\Event\ConfigureMenuEvent;
+use Knp\Bundle\MenuBundle\Events;
+use Knp\Menu\Provider\MenuProviderInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class EventEmittingProvider implements MenuProviderInterface
+{
+    protected $provider;
+    protected $eventDispatcher;
+    public function __construct (MenuProviderInterface $provider, EventDispatcherInterface $eventDispatcher)
+    {
+        $this->provider = $provider;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * Retrieves a menu by its name
+     *
+     * @param string $name
+     * @param array  $options
+     *
+     * @return \Knp\Menu\ItemInterface
+     * @throws \InvalidArgumentException if the menu does not exists
+     */
+    public function get($name, array $options = array())
+    {
+        $menu = $this->provider->get($name, $options);
+
+        $this->eventDispatcher->dispatch(Events::CONFIGURE, new ConfigureMenuEvent($this->provider, $menu, $name));
+
+        return $menu;
+    }
+
+    /**
+     * Checks whether a menu exists in this provider
+     *
+     * @param string $name
+     * @param array  $options
+     *
+     * @return boolean
+     */
+    public function has($name, array $options = array())
+    {
+        return $this->provider->has($name, $options);
+    }
+}

--- a/Resources/config/menu.xml
+++ b/Resources/config/menu.xml
@@ -10,6 +10,7 @@
         <parameter key="knp_menu.helper.class">Knp\Menu\Twig\Helper</parameter>
         <parameter key="knp_menu.matcher.class">Knp\Menu\Matcher\Matcher</parameter>
         <parameter key="knp_menu.menu_provider.chain.class">Knp\Menu\Provider\ChainProvider</parameter>
+        <parameter key="knp_menu.menu_provider.event_emitter.class">Knp\Bundle\MenuBundle\Provider\EventEmittingProvider</parameter>
         <parameter key="knp_menu.menu_provider.container_aware.class">Knp\Bundle\MenuBundle\Provider\ContainerAwareProvider</parameter>
         <parameter key="knp_menu.menu_provider.builder_alias.class">Knp\Bundle\MenuBundle\Provider\BuilderAliasProvider</parameter>
         <parameter key="knp_menu.renderer_provider.class">Knp\Bundle\MenuBundle\Renderer\ContainerAwareProvider</parameter>
@@ -34,6 +35,11 @@
 
         <service id="knp_menu.menu_provider.chain" class="%knp_menu.menu_provider.chain.class%" public="false">
             <argument type="collection" />
+        </service>
+
+        <service id="knp_menu.menu_provider.event_emitter" class="%knp_menu.menu_provider.event_mitter.class%" abstract="true" public="false">
+            <argument />
+            <argument type="service" id="event_dispatcher" />
         </service>
 
         <service id="knp_menu.menu_provider.container_aware" class="%knp_menu.menu_provider.container_aware.class%" public="false">

--- a/Resources/doc/events.md
+++ b/Resources/doc/events.md
@@ -1,100 +1,8 @@
 Using events to allow a menu to be extended
 ===========================================
 
-If you want to let different parts of your system hook into the building
-of your menu, a good way is to use an approach based on the Symfony2 EventDispatcher
-component.
-
-## Create the menu builder
-
-Your menu builder will create the base menu item and then dispatch an event
-to allow other parts of your application to add more stuff to it.
-
-```php
-<?php
-// src/Acme/DemoBundle/Menu/MainBuilder.php
-
-namespace Acme\DemoBundle\Menu;
-
-use Acme\DemoBundle\MenuEvents;
-use Acme\DemoBundle\Event\ConfigureMenuEvent;
-use Knp\Menu\FactoryInterface;
-use Symfony\Component\DependencyInjection\ContainerAware;
-
-class MainBuilder extends ContainerAware
-{
-    public function build(FactoryInterface $factory)
-    {
-        $menu = $factory->createItem('root');
-
-        $menu->setCurrentUri($this->container->get('request')->getRequestUri());
-        $menu->addChild('Dashboard', array('route' => '_acp_dashboard'));
-
-        $this->container->get('event_dispatcher')->dispatch(ConfigureMenuEvent::CONFIGURE, new ConfigureMenuEvent($factory, $menu));
-
-        return $menu;
-    }
-}
-```
-
-**Note:** This implementation assumes you use the BuilderAliasProvider (getting
-your menu as ``AcmeDemoBundle:MainBuilder:build``) but you could also define
-it as a service and inject the ``event_dispatcher`` service as a dependency.
-
-## Create the Event object
-
-The event object allows to pass some data to the listener. In this case,
-it will hold the menu being created and the factory.
-
-```php
-<?php
-// src/Acme/DemoBundle/Event/ConfigureMenuEvent.php
-
-namespace Acme\DemoBundle\Event;
-
-use Knp\Menu\FactoryInterface;
-use Knp\Menu\ItemInterface;
-use Symfony\Component\EventDispatcher\Event;
-
-class ConfigureMenuEvent extends Event
-{
-    const CONFIGURE = 'acme_demo.menu_configure';
-
-    private $factory;
-    private $menu;
-
-    /**
-     * @param \Knp\Menu\FactoryInterface $factory
-     * @param \Knp\Menu\ItemInterface $menu
-     */
-    public function __construct(FactoryInterface $factory, ItemInterface $menu)
-    {
-        $this->factory = $factory;
-        $this->menu = $menu;
-    }
-
-    /**
-     * @return \Knp\Menu\FactoryInterface
-     */
-    public function getFactory()
-    {
-        return $this->factory;
-    }
-
-    /**
-     * @return \Knp\Menu\ItemInterface
-     */
-    public function getMenu()
-    {
-        return $this->menu;
-    }
-}
-```
-
-**Note:** Following the Symfony2 best practices, the first segment of the
-event name will be the alias of the bundle, which allows avoiding conflicts.
-
-That's it. Your builder now provides a hook. Let's see how you can use it!
+To extend a menu, or change specific parts of it, you can just hook into the
+`knp_menu.menu_configure`-event.
 
 ## Create a listener
 
@@ -106,15 +14,20 @@ You can register as many listeners as you want for the event. Let's add one.
 
 namespace Acme\OtherBundle\EventListener;
 
-use Acme\DemoBundle\Event\ConfigureMenuEvent;
+use Knp\Bundle\MenuBundle\Event\ConfigureMenuEvent;
 
 class ConfigureMenuListener
 {
     /**
-     * @param \Acme\DemoBundle\Event\ConfigureMenuEvent $event
+     * @param \Knp\Bundle\MenuBundle\Event\ConfigureMenuEvent $event
      */
     public function onMenuConfigure(ConfigureMenuEvent $event)
     {
+        // \Acme\DemoBundle\Menu\MainBuilder::build()
+        if ($menu->getName() != 'AcmeDemoBundle:MainBuilder:build') {
+            return;
+        }
+
         $menu = $event->getMenu();
 
         $menu->addChild('Matches', array('route' => 'versus_rankedmatch_acp_matches_index'));
@@ -130,7 +43,7 @@ services:
     acme_other.configure_menu_listener:
         class: Acme\OtherBundle\EventListener\ConfigureMenuListener
         tags:
-          - { name: kernel.event_listener, event: acme_demo.menu_configure, method: onMenuConfigure }
+          - { name: kernel.event_listener, event: knp_menu.menu_configure, method: onMenuConfigure }
 ```
 
 **Note:** When using Symfony 2.1, you could also create your listener as


### PR DESCRIPTION
I've seen this and I wonder: Is theres a reason, why this isn't built-in?

The way the event is trigger looks quite generic

```php
$this->container->get('event_dispatcher')->dispatch(ConfigureMenuEvent::CONFIGURE, new ConfigureMenuEvent($factory, $menu));
```

So after (in this case) `build()` was called from [BuilderAliasProvider](https://github.com/KnpLabs/KnpMenuBundle/blob/master/Provider/BuilderAliasProvider.php#L64) the same class could trigger the event with the return value and the factory, that was previously passed as first argument of that method.