### PR TITLE
change of Silex namespace in KnpMenu

### DIFF
--- a/Resources/config/menu.xml
+++ b/Resources/config/menu.xml
@@ -6,7 +6,7 @@
 
     <parameters>
         <parameter key="knp_menu.factory.class">Knp\Menu\MenuFactory</parameter>
-        <parameter key="knp_menu.factory_extension.routing.class">Knp\Menu\Silex\RoutingExtension</parameter>
+        <parameter key="knp_menu.factory_extension.routing.class">Knp\Menu\Integration\Symfony\RoutingExtension</parameter>
         <parameter key="knp_menu.helper.class">Knp\Menu\Twig\Helper</parameter>
         <parameter key="knp_menu.matcher.class">Knp\Menu\Matcher\Matcher</parameter>
         <parameter key="knp_menu.menu_provider.chain.class">Knp\Menu\Provider\ChainProvider</parameter>
@@ -64,7 +64,7 @@
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" />
         </service>
 
-        <service id="knp_menu.voter.router" class="Knp\Menu\Silex\Voter\RouteVoter">
+        <service id="knp_menu.voter.router" class="Knp\Menu\Matcher\Voter\RouteVoter">
             <tag name="knp_menu.voter" request="true" />
         </service>
     </services>

--- a/Tests/EventListener/VoterInitializerListenerTest.php
+++ b/Tests/EventListener/VoterInitializerListenerTest.php
@@ -17,7 +17,7 @@ class MenuPassTest extends \PHPUnit_Framework_TestCase
             ->method('getRequestType')
             ->will($this->returnValue(HttpKernelInterface::SUB_REQUEST));
 
-        $voter = $this->getMockBuilder('Knp\Menu\Silex\Voter\RouteVoter')
+        $voter = $this->getMockBuilder('Knp\Menu\Matcher\RouteVoter')
             ->disableOriginalConstructor()
             ->getMock();
         $voter->expects($this->never())
@@ -43,7 +43,7 @@ class MenuPassTest extends \PHPUnit_Framework_TestCase
             ->method('getRequest')
             ->will($this->returnValue($request));
 
-        $voter = $this->getMockBuilder('Knp\Menu\Silex\Voter\RouteVoter')
+        $voter = $this->getMockBuilder('Knp\Menu\Matcher\RouteVoter')
             ->disableOriginalConstructor()
             ->getMock();
         $voter->expects($this->once())


### PR DESCRIPTION
Updated namespaces for all the Silex folder in KnpMenu

See:
https://github.com/KnpLabs/KnpMenu/commit/47a2233f93831fed2e27f205eb771ca2e40efe95
and
https://github.com/KnpLabs/KnpMenu/commit/c196a37de14e46f89b4fef86c22e1dd44ea1db02
