### PR TITLE
Updated the bundle's installation instructions

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -22,76 +22,47 @@ Welcome to KnpMenuBundle - creating menus is fun again!
 
 ## Installation
 
-### Step 1) Get the bundle and the library
+### Step 1: Download the Bundle
 
-First, grab the KnpMenu library and KnpMenuBundle. There are three different
-ways to do this:
-
-
-#### Method a) Using Composer (Symfony 2.1 or higher)
-
-Open your command console, browse to your project and execute the following:
+Open a command console, enter your project directory and execute the
+following command to download the latest stable version of this bundle:
 
 ```bash
 $ composer require knplabs/knp-menu-bundle
 ```
 
-#### Method b) Using the `deps` file (legacy Symfony 2.0 version)
+This command requires you to have Composer installed globally, as explained
+in the [installation chapter](https://getcomposer.org/doc/00-intro.md)
+of the Composer documentation.
 
-Add the following lines to your  `deps` file and then run `php bin/vendors
-install`:
+### Step 2: Enable the Bundle
 
-```
-[KnpMenu]
-    git=https://github.com/KnpLabs/KnpMenu.git
+Then, enable the bundle by adding the following line in the `app/AppKernel.php`
+file of your project:
 
-[KnpMenuBundle]
-    git=https://github.com/KnpLabs/KnpMenuBundle.git
-    target=bundles/Knp/Bundle/MenuBundle
-```
-
-Then, add the following two namespace entries to the `registerNamespaces` call
-in your autoloader:
-
-``` php
-<?php
-// app/autoload.php
-$loader->registerNamespaces(array(
-    // ...
-    'Knp\Bundle' => __DIR__.'/../vendor/bundles',
-    'Knp\Menu'   => __DIR__.'/../vendor/KnpMenu/src',
-    // ...
-));
-```
-
-#### Method c) Using Git submodules
-
-Run the following commands to bring in the needed libraries as submodules.
-
-```bash
-git submodule add https://github.com/KnpLabs/KnpMenuBundle.git vendor/bundles/Knp/Bundle/MenuBundle
-git submodule add https://github.com/KnpLabs/KnpMenu.git vendor/KnpMenu
-```
-
-### Step 2) Register the bundle
-
-To start using the bundle, register it in your Kernel:
-
-``` php
+```php
 <?php
 // app/AppKernel.php
 
-public function registerBundles()
+// ...
+class AppKernel extends Kernel
 {
-    $bundles = array(
+    public function registerBundles()
+    {
+        $bundles = array(
+            // ...
+
+            new Knp\Bundle\MenuBundle\KnpMenuBundle(),
+        );
+
         // ...
-        new Knp\Bundle\MenuBundle\KnpMenuBundle(),
-    );
+    }
+
     // ...
 }
 ```
 
-### Step 3) (optional) Configure the bundle
+### Step 3: (optional) Configure the bundle
 
 The bundle comes with a sensible default configuration, which is listed below.
 If you skip this step, these defaults will be used.


### PR DESCRIPTION
The Symfony Community is trying to update the installation instructions for all bundles and we've started with the major ones, such as KnpMenuBundle. That's why I propose to update the instructions to use the latest Composer features and to clearly show that Symfony 2.0 stuff is really legacy.
