### PR TITLE
Fixed version number in the documentation.

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -14,7 +14,7 @@ following command to download the latest stable version of this bundle:
 
 .. code-block:: bash
 
-    $ composer require knplabs/knp-menu-bundle "~2"
+    $ composer require knplabs/knp-menu-bundle "~2.0"
 
 This command requires you to have Composer installed globally, as explained
 in the `installation chapter`_ of the Composer documentation.


### PR DESCRIPTION
`~2` can be a problem if we break the compatibility in ~3 (and we will)