### PR TITLE
Add a menu provider registering builders as services

### DIFF
--- a/DependencyInjection/Compiler/MenuBuilderPass.php
+++ b/DependencyInjection/Compiler/MenuBuilderPass.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Knp\Bundle\MenuBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+/**
+ * This compiler pass registers the menu builders in the BuilderServiceProvider.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class MenuBuilderPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $definition = $container->getDefinition('knp_menu.menu_provider.builder_service');
+
+        $menuBuilders = array();
+        foreach ($container->findTaggedServiceIds('knp_menu.menu_builder') as $id => $tags) {
+            foreach ($tags as $attributes) {
+                if (empty($attributes['alias'])) {
+                    throw new \InvalidArgumentException(sprintf('The alias is not defined in the "knp_menu.menu_builder" tag for the service "%s"', $id));
+                }
+                if (empty($attributes['method'])) {
+                    throw new \InvalidArgumentException(sprintf('The method is not defined in the "knp_menu.menu_builder" tag for the service "%s"', $id));
+                }
+                $menuBuilders[$attributes['alias']] = array($id, $attributes['method']);
+            }
+        }
+        $definition->replaceArgument(1, $menuBuilders);
+    }
+}

--- a/DependencyInjection/Compiler/MenuBuilderPass.php
+++ b/DependencyInjection/Compiler/MenuBuilderPass.php
@@ -18,6 +18,16 @@ class MenuBuilderPass implements CompilerPassInterface
 
         $menuBuilders = array();
         foreach ($container->findTaggedServiceIds('knp_menu.menu_builder') as $id => $tags) {
+            $builderDefinition = $container->getDefinition($id);
+
+            if (!$builderDefinition->isPublic()) {
+                throw new \InvalidArgumentException(sprintf('Menu builder services must be public but "%s" is a private service.', $id));
+            }
+
+            if ($builderDefinition->isAbstract()) {
+                throw new \InvalidArgumentException(sprintf('Abstract services cannot be registered as menu builders but "%s" is.', $id));
+            }
+
             foreach ($tags as $attributes) {
                 if (empty($attributes['alias'])) {
                     throw new \InvalidArgumentException(sprintf('The alias is not defined in the "knp_menu.menu_builder" tag for the service "%s"', $id));

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,6 +30,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->booleanNode('builder_alias')->defaultTrue()->end()
                         ->booleanNode('container_aware')->defaultTrue()->end()
+                        ->booleanNode('builder_service')->defaultTrue()->end()
                     ->end()
                 ->end()
                 ->arrayNode('twig')

--- a/KnpMenuBundle.php
+++ b/KnpMenuBundle.php
@@ -7,6 +7,7 @@ use Knp\Bundle\MenuBundle\DependencyInjection\Compiler\AddProvidersPass;
 use Knp\Bundle\MenuBundle\DependencyInjection\Compiler\AddRenderersPass;
 use Knp\Bundle\MenuBundle\DependencyInjection\Compiler\AddTemplatePathPass;
 use Knp\Bundle\MenuBundle\DependencyInjection\Compiler\AddVotersPass;
+use Knp\Bundle\MenuBundle\DependencyInjection\Compiler\MenuBuilderPass;
 use Knp\Bundle\MenuBundle\DependencyInjection\Compiler\MenuPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -18,6 +19,7 @@ class KnpMenuBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new MenuPass());
+        $container->addCompilerPass(new MenuBuilderPass());
         $container->addCompilerPass(new AddExtensionsPass());
         $container->addCompilerPass(new AddProvidersPass());
         $container->addCompilerPass(new AddRenderersPass());

--- a/Provider/BuilderServiceProvider.php
+++ b/Provider/BuilderServiceProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Knp\Bundle\MenuBundle\Provider;
+
+use Knp\Menu\Provider\MenuProviderInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * This provider uses methods of services to build menus.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class BuilderServiceProvider implements MenuProviderInterface
+{
+    private $container;
+    private $menuBuilders;
+
+    public function __construct(ContainerInterface $container, array $menuBuilders = array())
+    {
+        $this->container = $container;
+        $this->menuBuilders = $menuBuilders;
+    }
+
+    public function get($name, array $options = array())
+    {
+        if (!isset($this->menuBuilders[$name])) {
+            throw new \InvalidArgumentException(sprintf('The menu "%s" is not defined.', $name));
+        }
+
+        if (!is_array($this->menuBuilders[$name]) || 2 !== count($this->menuBuilders[$name])) {
+            throw new \InvalidArgumentException(sprintf('The menu builder definition for the menu "%s" is invalid. It should be an array (serviceId, method)', $name));
+        }
+
+        list($id, $method) = $this->menuBuilders[$name];
+
+        return $this->container->get($id)->$method($options);
+    }
+
+    public function has($name, array $options = array())
+    {
+        return isset($this->menuBuilders[$name]);
+    }
+}

--- a/Resources/config/menu.xml
+++ b/Resources/config/menu.xml
@@ -43,6 +43,11 @@
             <argument type="collection" />
         </service>
 
+        <service id="knp_menu.menu_provider.builder_service" class="Knp\Bundle\MenuBundle\Provider\BuilderServiceProvider" public="false">
+            <argument type="service" id="service_container" />
+            <argument type="collection" />
+        </service>
+
         <service id="knp_menu.menu_provider.builder_alias" class="%knp_menu.menu_provider.builder_alias.class%" public="false">
             <argument type="service" id="kernel" />
             <argument type="service" id="service_container" />

--- a/Resources/doc/disabling_providers.rst
+++ b/Resources/doc/disabling_providers.rst
@@ -1,0 +1,22 @@
+Disabling the Core Menu Providers
+=================================
+
+To be able to use different menu providers together (the builder-service-based
+one, the container-based one and the convention-based one for instance),
+a chain provider is used. However, it is not used when only one provider
+is enabled to increase performance by getting rid of the wrapping. If you
+don't want to use the built-in providers, you can disable them through the
+configuration:
+
+.. code-block:: yaml
+
+    #app/config/config.yml
+    knp_menu:
+        providers:
+            builder_alias: false    # disable the builder-alias-based provider
+            builder_service: false
+            container_aware: true   # keep this one enabled. Can be omitted as it is the default
+
+.. note::
+
+    All providers are enabled by default.

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -72,7 +72,7 @@ If you skip this step, these defaults will be used.
         <?xml version="1.0" charset="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services"
             xmlns:knp-menu="http://knplabs.com/schema/dic/menu">
-        
+
             <!--
                 templating:       if true, enabled the helper for PHP templates
                 default-renderer: the renderer to use, list is also available by default
@@ -207,11 +207,22 @@ then render it via ``AppBundle:Builder:sidebarMenu``.
 That's it! The menu is *very* configurable. For more details, see the
 `KnpMenu documentation`_.
 
-Method b) A menu as a service
+Method b) A menu builder as a service
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For information on how to register a menu builder as a service, read
+:doc:`Creating Menu Builders as Services <menu_builder_service>`.
+
+
+Method c) A menu as a service
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For information on how to register a service and tag it as a menu, read
 :doc:`Creating Menus as Services <menu_service>`.
+
+.. note::
+
+    To improve performances, you can :doc:`disable providers you don't need <disabling_providers>`.
 
 Rendering Menus
 ---------------

--- a/Resources/doc/menu_builder_service.rst
+++ b/Resources/doc/menu_builder_service.rst
@@ -1,24 +1,13 @@
-Creating Menus as Services
-==========================
-
-.. note::
-
-    Registering a menu as service comes with several limitations:
-
-    - it does not allow to use builder options
-    - it reuses the same instance several times in case you render the same
-      menu several times, which can has weird side-effects.
-
-    It is recommended to register only :doc:`menu builders as services <menu_builder_service>`
-    instead.
+Creating Menu Builders as Services
+==================================
 
 This bundle gives you a really convenient way to create menus by following
 a convention and - if needed - injecting the entire container.
 
 However, if you want to, you can instead choose to create a service for your
-menu object. The advantage of this method is that you can inject the exact
-dependencies that your menu needs, instead of injecting the entire service
-container. This can lead to code that is more testable and also potentially
+menu builder. The advantage of this method is that you can inject the exact
+dependencies that your menu builder needs, instead of injecting the entire
+service container. This can lead to code that is more testable and also potentially
 more reusable. The disadvantage is that it needs just a little more setup.
 
 Start by creating a builder for your menu. You can stick as many menus into
@@ -40,13 +29,15 @@ builder classes in your application:
 
         /**
          * @param FactoryInterface $factory
+         *
+         * Add any other dependency you need
          */
         public function __construct(FactoryInterface $factory)
         {
             $this->factory = $factory;
         }
 
-        public function createMainMenu(RequestStack $requestStack)
+        public function createMainMenu(array $options)
         {
             $menu = $this->factory->createItem('root');
 
@@ -57,8 +48,7 @@ builder classes in your application:
         }
     }
 
-Next, register two services: one for your menu builder, and one for the menu
-object created by the ``createMainMenu`` method:
+Next, register your menu builder as service and register its ``createMainMenu`` method as a menu builder:
 
 .. code-block:: yaml
 
@@ -67,13 +57,8 @@ object created by the ``createMainMenu`` method:
         app.menu_builder:
             class: AppBundle\Menu\MenuBuilder
             arguments: ["@knp_menu.factory"]
-
-        app.main_menu:
-            class: Knp\Menu\MenuItem # the service definition requires setting the class
-            factory: ["@app.menu_builder", createMainMenu]
-            arguments: ["@request_stack"]
             tags:
-                - { name: knp_menu.menu, alias: main } # The alias is what is used to retrieve the menu
+                - { name: knp_menu.menu_builder, method: createMainMenu, alias: main } # The alias is what is used to retrieve the menu
 
         # ...
 
@@ -81,11 +66,6 @@ object created by the ``createMainMenu`` method:
 
     The menu service must be public as it will be retrieved at runtime to keep
     it lazy-loaded.
-
-.. note::
-
-    If you are using Symfony `2.5` or older version please check the `Using a Factory to Create Services`_
-    article for correct factories syntax corresponding to your version.
 
 You can now render the menu directly in a template via the name given in the
 ``alias`` key above:
@@ -107,11 +87,14 @@ is simple! Start by adding a new method to your builder:
     {
         // ...
 
-        public function createSidebarMenu(RequestStack $requestStack)
+        public function createSidebarMenu(array $options)
         {
             $menu = $this->factory->createItem('sidebar');
 
-            $menu->addChild('Home', array('route' => 'homepage'));
+            if (isset($options['include_homepage']) && $options['include_homepage']) {
+                $menu->addChild('Home', array('route' => 'homepage'));
+            }
+
             // ... add more children
 
             return $menu;
@@ -125,12 +108,12 @@ Now, create a service for *just* your new menu, giving it a new name, like
 
     # app/config/services.yml
     services:
-        app.sidebar_menu:
-            class: Knp\Menu\MenuItem
-            factory: ["@app.menu_builder", createMainMenu]
-            arguments: ["@request_stack"]
+        app.menu_builder:
+            class: AppBundle\Menu\MenuBuilder
+            arguments: ["@knp_menu.factory"]
             tags:
-                - { name: knp_menu.menu, alias: sidebar } # Named "sidebar" this time
+                - { name: knp_menu.menu_builder, method: createMainMenu, alias: main } # the previous menu
+                - { name: knp_menu.menu_builder, method: createSidebarMenu, alias: sidebar } # Named "sidebar" this time
 
         # ...
 
@@ -138,6 +121,5 @@ It can now be rendered, just like the other menu:
 
 .. code-block:: html+jinja
 
-    {{ knp_menu_render('sidebar') }}
-
-.. _`Using a Factory to Create Services`: http://symfony.com/doc/2.5/components/dependency_injection/factories.html
+    {% set menu = knp_menu_get('sidebar', {include_homepage: false}) %}
+    {{ knp_menu_render(menu) }}

--- a/Tests/DependencyInjection/Compiler/MenuBuilderPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MenuBuilderPassTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Knp\Bundle\MenuBundle\Tests\DependencyInjection\Compiler;
+
+use Knp\Bundle\MenuBundle\DependencyInjection\Compiler\MenuBuilderPass;
+
+class MenuBuilderPassTest extends \PHPUnit_Framework_TestCase
+{
+    private $containerBuilder;
+    private $definition;
+
+    /**
+     * @var MenuBuilderPass
+     */
+    private $pass;
+
+    protected function setUp()
+    {
+        $this->containerBuilder = $this->prophesize('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $this->definition = $this->prophesize('Symfony\Component\DependencyInjection\Definition');
+        $this->pass = new MenuBuilderPass();
+
+        $this->containerBuilder->getDefinition('knp_menu.menu_provider.builder_service')->willReturn($this->definition);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The alias is not defined in the "knp_menu.menu_builder" tag for the service "id"
+     */
+    public function testFailsWhenAliasIsMissing()
+    {
+        $this->containerBuilder->findTaggedServiceIds('knp_menu.menu_builder')->willReturn(array('id' => array(array('alias' => ''))));
+
+        $this->pass->process($this->containerBuilder->reveal());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The method is not defined in the "knp_menu.menu_builder" tag for the service "id"
+     */
+    public function testFailsWhenMethodIsMissing()
+    {
+        $this->containerBuilder->findTaggedServiceIds('knp_menu.menu_builder')->willReturn(array('id' => array(array('alias' => 'foo'))));
+
+        $this->pass->process($this->containerBuilder->reveal());
+    }
+
+    public function testReplaceArgument()
+    {
+        $taggedServiceIds = array(
+            'id1' => array(array('alias' => 'foo', 'method' => 'fooMenu'), array('alias' => 'bar', 'method' => 'bar')),
+            'id2' => array(array('alias' => 'foo', 'method' => 'fooBar'), array('alias' => 'baz', 'method' => 'bar')),
+        );
+        $this->containerBuilder->findTaggedServiceIds('knp_menu.menu_builder')->willReturn($taggedServiceIds);
+
+        $menuBuilders = array(
+            'foo' => array('id2', 'fooBar'),
+            'bar' => array('id1', 'bar'),
+            'baz' => array('id2', 'bar'),
+        );
+        $this->definition->replaceArgument(1, $menuBuilders)->shouldBeCalled();
+
+        $this->pass->process($this->containerBuilder->reveal());
+    }
+}

--- a/Tests/Provider/BuilderServiceProviderTest.php
+++ b/Tests/Provider/BuilderServiceProviderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Knp\Bundle\MenuBundle\Tests\Provider;
+
+use Knp\Bundle\MenuBundle\Provider\BuilderServiceProvider;
+
+class BuilderServiceProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHas()
+    {
+        $provider = new BuilderServiceProvider(
+            $this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface')->reveal(),
+            array('first' => array('first', 'method'), 'second' => array('dummy', 'menu'))
+        );
+        $this->assertTrue($provider->has('first'));
+        $this->assertTrue($provider->has('second'));
+        $this->assertFalse($provider->has('third'));
+    }
+
+    public function testGetExistingMenu()
+    {
+        $menu = $this->prophesize('Knp\Menu\ItemInterface');
+        $container = $this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface');
+        $builder = $this->prophesize('Knp\Bundle\MenuBundle\Tests\Provider\Builder');
+        $container->get('menu_builder')->willReturn($builder);
+        $builder->build(array('test' => 'foo'))->willReturn($menu);
+
+        $provider = new BuilderServiceProvider($container->reveal(), array('default' => array('menu_builder', 'build')));
+        $this->assertSame($menu->reveal(), $provider->get('default', array('test' => 'foo')));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The menu "non-existent" is not defined.
+     */
+    public function testThrowsExceptionWhenGettingUndefinedMenu()
+    {
+        $provider = new BuilderServiceProvider($this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface')->reveal());
+        $provider->get('non-existent');
+    }
+
+    /**
+     * @dataProvider provideInvalidMenuDefinitions
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The menu builder definition for the menu "invalid" is invalid. It should be an array (serviceId, method)
+     */
+    public function testThrowsExceptionWhenGettingInvalidMenu($definition)
+    {
+        $provider = new BuilderServiceProvider($this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface')->reveal(), array('invalid' => $definition));
+        $provider->get('invalid');
+    }
+
+    public function provideInvalidMenuDefinitions()
+    {
+        return array(
+            'string' => array('def'),
+            'missing array elements' => array(array('id')),
+            'too much array elements' => array(array('id', 'method', 'foo')),
+        );
+    }
+}
+
+interface Builder
+{
+    public function build(array $options);
+}


### PR DESCRIPTION
This is an alternative to #272

This code is running in production at Incenteev since 2 years (in a different namespace of course) and I finally took the time to extract it to KnpMenuBundle.
I wrote the documentation about the feature, so you can look at it to see how it works.