### PR TITLE
Add a priority to allow controlling the order of voters

### DIFF
--- a/Tests/DependencyInjection/Compiler/AddVotersPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddVotersPassTest.php
@@ -32,6 +32,9 @@ class AddVotersPassTest extends \PHPUnit_Framework_TestCase
         $definitionMock->expects($this->at(1))
             ->method('addMethodCall')
             ->with($this->equalTo('addVoter'), $this->equalTo(array(new Reference('foo'))));
+        $definitionMock->expects($this->at(2))
+            ->method('addMethodCall')
+            ->with($this->equalTo('addVoter'), $this->equalTo(array(new Reference('bar'))));
 
         $listenerMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')
             ->disableOriginalConstructor()
@@ -47,7 +50,7 @@ class AddVotersPassTest extends \PHPUnit_Framework_TestCase
         $containerBuilderMock->expects($this->once())
             ->method('findTaggedServiceIds')
             ->with($this->equalTo('knp_menu.voter'))
-            ->will($this->returnValue(array('id' => array('tag1' => array(), 'tag2' => array('request' => false)), 'foo' => array('tag1' => array('request' => true)))));
+            ->will($this->returnValue(array('id' => array(array()), 'bar' => array(array('priority' => -5, 'request' => false)), 'foo' => array(array('request' => true)))));
         $containerBuilderMock->expects($this->at(1))
             ->method('getDefinition')
             ->with($this->equalTo('knp_menu.matcher'))


### PR DESCRIPTION
The order of voters can be important in 2 cases:

- the first voter which does not abstain wins the decision. In case multiple voters can take opposite decisions on the same item, the order is important (this will never happen for matchers shipped in the library as they either match or abstain, but never reject a match)
- the order of matchers can affect performance: if one of the matchers performs an heavy computation, running it after other matchers can avoid calling it when another matcher is taking a decision.

Replaces #268