### PR TITLE
Fix documentation about MenuBuilder as a service

### DIFF
--- a/Resources/doc/menu_builder_service.rst
+++ b/Resources/doc/menu_builder_service.rst
@@ -121,5 +121,5 @@ It can now be rendered, just like the other menu:
 
 .. code-block:: html+jinja
 
-    {% set menu = knp_menu_get('sidebar', {include_homepage: false}) %}
+    {% set menu = knp_menu_get('sidebar', [], {include_homepage: false}) %}
     {{ knp_menu_render(menu) }}


### PR DESCRIPTION
Options sent to the MenuBuilder are in 3rd position when calling knp_menu_get