### PR TITLE
Fixed documentation issues

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -66,7 +66,7 @@ If you skip this step, these defaults will be used.
             # the renderer to use, list is also available by default
             default_renderer: twig
 
-    .. code-bock:: xml
+    .. code-block:: xml
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" charset="UTF-8" ?>
@@ -131,7 +131,7 @@ An example builder class would look like this:
     class Builder implements ContainerAwareInterface
     {
         use ContainerAwareTrait;
-        
+
         public function mainMenu(FactoryInterface $factory, array $options)
         {
             $menu = $factory->createItem('root');
@@ -311,11 +311,14 @@ of the ``knp_menu_get`` function:
 More Advanced Stuff
 -------------------
 
-* :doc:`Menus as Services <menu_service>`
-* :doc:`Custom Menu Renderer <custom_renderer>`
-* :doc:`Custom Menu Provider <custom_provider>`
-* :doc:`I18n for your menu labels <i18n>`
-* :doc:`Using events to allow extending the menu <events>`
+.. toctree::
+    :maxdepth: 1
+
+    menu_service
+    custom_renderer
+    custom_provider
+    i18n
+    events
 
 .. _`installation chapter`: https://getcomposer.org/doc/00-intro.md
 .. _`KnpMenu documentation`: https://github.com/KnpLabs/KnpMenu/blob/master/doc/01-Basic-Menus.markdown


### PR DESCRIPTION
We recently reenabled the "docs build error reporting" on symfony.com and these are the errors shows for this bundle:

```
var/docs/rst/knplabs-knpmenu-bundle/en/master/index.rst:69: ERROR: Unknown directive type "code-bock".
.. code-bock:: xml
    <!-- app/config/config.xml -->
    <?xml version="1.0" charset="UTF-8" ?>
    <container xmlns="http://symfony.com/schema/dic/services"
        xmlns:knp-menu="http://knplabs.com/schema/dic/menu">
        <!--
            templating:       if true, enabled the helper for PHP templates
            default-renderer: the renderer to use, list is also available by default
        -->
        <knp-menu:config
            templating="false"
            default-renderer="twig"
        >
            <!-- add enabled="false" to disable the Twig extension and the TwigRenderer -->
            <knp-menu:twig template="knp_menu.html.twig"/>
        </knp-menu:config>
    </container>
var/docs/rst/knplabs-knpmenu-bundle/en/master/custom_provider.rst:: WARNING: document isn't included in any toctree
var/docs/rst/knplabs-knpmenu-bundle/en/master/custom_renderer.rst:: WARNING: document isn't included in any toctree
var/docs/rst/knplabs-knpmenu-bundle/en/master/events.rst:: WARNING: document isn't included in any toctree
var/docs/rst/knplabs-knpmenu-bundle/en/master/i18n.rst:: WARNING: document isn't included in any toctree
var/docs/rst/knplabs-knpmenu-bundle/en/master/menu_service.rst:: WARNING: document isn't included in any toctree
```

This PR tries to fix all these errors.