### PR TITLE
Fixed a code block directive

### DIFF
--- a/Resources/doc/i18n.rst
+++ b/Resources/doc/i18n.rst
@@ -19,7 +19,7 @@ The items "Home" and "Login" can now be translated in the message domain:
         Home: Accueil
         Login: Connexion
 
-    .. code-block:: xliff
+    .. code-block:: xml
 
         <!-- app/Resources/translations/messages.fr.xlf -->
         <?xml version="1.0"?>


### PR DESCRIPTION
`xliff` is not a valid value for the `code-block` directive. Let's use `xml` instead: 

Error details:

```
Exception occurred:
File "sphinx/configurationblock.py", line 60, in run
  innernode = nodes.emphasis(self.formats[child['language']], self.formats[child['language']])
  KeyError: u'xliff'
```