### PR TITLE
handle alias for factory and add sanity checks for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Menu extensions now also work if you replace the knp_menu.factory service with an alias
 * Menu items are translated in the default template
 
 ## 2.1.1 (2015-12-15)

--- a/Tests/DependencyInjection/Compiler/AddExtensionsPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddExtensionsPassTest.php
@@ -2,6 +2,7 @@
 namespace Knp\Bundle\MenuBundle\Tests\DependencyInjection\Compiler;
 
 use Knp\Bundle\MenuBundle\DependencyInjection\Compiler\AddExtensionsPass;
+use Knp\Menu\FactoryInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 class AddExtensionsPassTest extends \PHPUnit_Framework_TestCase
@@ -10,7 +11,7 @@ class AddExtensionsPassTest extends \PHPUnit_Framework_TestCase
     {
         $containerBuilder = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
         $containerBuilder->expects($this->once())
-            ->method('hasDefinition')
+            ->method('has')
             ->will($this->returnValue(false));
         $containerBuilder->expects($this->never())
             ->method('findTaggedServiceIds');
@@ -22,33 +23,96 @@ class AddExtensionsPassTest extends \PHPUnit_Framework_TestCase
 
     public function testProcessWithAlias()
     {
+        $menuFactoryClass = 'Knp\Bundle\MenuBundle\Tests\DependencyInjection\Compiler\MenuFactoryMock';
+
         $definitionMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')
             ->disableOriginalConstructor()
             ->getMock();
         $definitionMock->expects($this->at(0))
-            ->method('addMethodCall')
-            ->with($this->equalTo('addExtension'), $this->equalTo(array(new Reference('id'), 0)));
+            ->method('getClass')
+            ->will($this->returnValue($menuFactoryClass));
         $definitionMock->expects($this->at(1))
             ->method('addMethodCall')
-            ->with($this->equalTo('addExtension'), $this->equalTo(array(new Reference('id'), 12)));
+            ->with($this->equalTo('addExtension'), $this->equalTo(array(new Reference('id'), 0)));
         $definitionMock->expects($this->at(2))
+            ->method('addMethodCall')
+            ->with($this->equalTo('addExtension'), $this->equalTo(array(new Reference('id'), 12)));
+        $definitionMock->expects($this->at(3))
             ->method('addMethodCall')
             ->with($this->equalTo('addExtension'), $this->equalTo(array(new Reference('foo'), -4)));
 
+        $parameterBagMock = $this->getMock('Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface');
+        $parameterBagMock->expects($this->once())
+            ->method('resolveValue')
+            ->with($menuFactoryClass)
+            ->will($this->returnValue($menuFactoryClass));
+
         $containerBuilderMock = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
         $containerBuilderMock->expects($this->once())
-            ->method('hasDefinition')
+            ->method('has')
             ->will($this->returnValue(true));
         $containerBuilderMock->expects($this->once())
             ->method('findTaggedServiceIds')
             ->with($this->equalTo('knp_menu.factory_extension'))
             ->will($this->returnValue(array('id' => array('tag1' => array(), 'tag2' => array('priority' => 12)), 'foo' => array('tag1' => array('priority' => -4)))));
         $containerBuilderMock->expects($this->once())
-            ->method('getDefinition')
+            ->method('findDefinition')
             ->with($this->equalTo('knp_menu.factory'))
             ->will($this->returnValue($definitionMock));
+        $containerBuilderMock->expects($this->once())
+            ->method('getParameterBag')
+            ->will($this->returnValue($parameterBagMock));
 
         $menuPass = new AddExtensionsPass();
         $menuPass->process($containerBuilderMock);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     */
+    public function testMissingAddExtension()
+    {
+        $definitionMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $definitionMock->expects($this->at(0))
+            ->method('getClass')
+            ->will($this->returnValue('SimpleMenuFactory'));
+
+        $parameterBagMock = $this->getMock('Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface');
+        $parameterBagMock->expects($this->once())
+            ->method('resolveValue')
+            ->with('SimpleMenuFactory')
+            ->will($this->returnValue('SimpleMenuFactory'));
+
+        $containerBuilderMock = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $containerBuilderMock->expects($this->once())
+            ->method('has')
+            ->will($this->returnValue(true));
+        $containerBuilderMock->expects($this->once())
+            ->method('findTaggedServiceIds')
+            ->with($this->equalTo('knp_menu.factory_extension'))
+            ->will($this->returnValue(array('id' => array('tag1' => array(), 'tag2' => array('priority' => 12)), 'foo' => array('tag1' => array('priority' => -4)))));
+        $containerBuilderMock->expects($this->once())
+            ->method('findDefinition')
+            ->with($this->equalTo('knp_menu.factory'))
+            ->will($this->returnValue($definitionMock));
+        $containerBuilderMock->expects($this->once())
+            ->method('getParameterBag')
+            ->will($this->returnValue($parameterBagMock));
+
+        $menuPass = new AddExtensionsPass();
+        $menuPass->process($containerBuilderMock);
+    }
+}
+
+class MenuFactoryMock implements FactoryInterface
+{
+    public function createItem($name, array $options = array())
+    {
+    }
+
+    public function addExtension()
+    {
     }
 }


### PR DESCRIPTION
in https://github.com/symfony-cmf/menu-bundle/issues/249 we noticed that when we replace knp_menu.factory with an alias, the compiler pass stops working. once i fixed that, i noticed that this compiler pass assumes a method that is not in the FactoryInterface.

with these changes, we can handle an alias and we fail with a better error message than a fatal error at run time when the factory is instantiated.