### PR TITLE
Fix wrong event name in Resources/doc/events.rst

### DIFF
--- a/Resources/doc/events.rst
+++ b/Resources/doc/events.rst
@@ -64,7 +64,7 @@ it will hold the menu being created and the factory.
 
     class ConfigureMenuEvent extends Event
     {
-        const CONFIGURE = 'acme_demo.menu_configure';
+        const CONFIGURE = 'app.menu_configure';
 
         private $factory;
         private $menu;


### PR DESCRIPTION
This is probably a leftover from https://github.com/KnpLabs/KnpMenuBundle/commit/8cf6329e63e4bb8a14336c6facaa8d5f48f80f52.