### PR TITLE
Removed unused dependency from events.rst

### DIFF
--- a/Resources/doc/events.rst
+++ b/Resources/doc/events.rst
@@ -17,7 +17,6 @@ to allow other parts of your application to add more stuff to it.
 
   namespace AppBundle\Menu;
 
-  use AppBundle\MenuEvents;
   use AppBundle\Event\ConfigureMenuEvent;
   use Knp\Menu\FactoryInterface;
   use Symfony\Component\DependencyInjection\ContainerAware;


### PR DESCRIPTION
I've noticed this class is neither defined nor used anywhere, it looks like it was predecessor of `AppBundle\Event\ConfigureMenuEvent`.