### PR TITLE
Add templating component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
         "symfony/expression-language": "~2.4|~3.0",
         "symfony/templating": "~2.3|~3.0"
     },
+    "suggest": {
+        "symfony/templating": "When not using Twig but the Symfony templating component to render menus. (~2.3|~3.0)"
+    },
     "autoload":     {
         "psr-4": { "Knp\\Bundle\\MenuBundle\\": "" }
     },

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     ],
     "require":      {
         "knplabs/knp-menu":         "~2.2",
-        "symfony/framework-bundle": "~2.3|~3.0"
+        "symfony/framework-bundle": "~2.3|~3.0",
+        "symfony/templating": "~2.3|~3.0"
     },
     "require-dev":  {
         "symfony/phpunit-bridge": "~2.7|~3.0",

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
     ],
     "require":      {
         "knplabs/knp-menu":         "~2.2",
-        "symfony/framework-bundle": "~2.3|~3.0",
-        "symfony/templating": "~2.3|~3.0"
+        "symfony/framework-bundle": "~2.3|~3.0"
     },
     "require-dev":  {
         "symfony/phpunit-bridge": "~2.7|~3.0",
-        "symfony/expression-language": "~2.4|~3.0"
+        "symfony/expression-language": "~2.4|~3.0",
+        "symfony/templating": "~2.3|~3.0"
     },
     "autoload":     {
         "psr-4": { "Knp\\Bundle\\MenuBundle\\": "" }


### PR DESCRIPTION
Templating component is no longer required by symfony/framework-bundle, so we need to require it