### PR TITLE
Update travis.yml with PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ php:
     - 5.5
     - 5.6
     - 7.0
-    - hhvm
+    - 7.1
 
 matrix:
     include:
@@ -24,6 +24,8 @@ matrix:
           env: SYMFONY_VERSION='2.3.*'
         - php: 5.6
           env: SYMFONY_VERSION='3.0.*@dev'
+        - php: hhvm
+          dist: trusty
 
 before_install:
     - composer self-update # remove this once the Travis upgrade of February 2015 is deployed


### PR DESCRIPTION
As PHP 7.1 is out since December (6 months) I think is useful to test the codebase against it.