### PR TITLE
Improve the CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,14 @@ sudo: false
 cache:
     directory:
         - $HOME/.composer/cache/files
+        - $HOME/symfony-bridge/.phpunit
+
+env:
+    global:
+        - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
+        - SYMFONY_PHPUNIT_REMOVE="symfony/yaml" # keep Prophecy
 
 php:
-    - 5.3
     - 5.4
     - 5.5
     - 5.6
@@ -17,21 +22,23 @@ php:
 matrix:
     include:
         - php: 5.3
+          dist: precise # PHP 5.3 is not available on Trusty
+        - php: 5.6
           env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' SYMFONY_DEPRECATIONS_HELPER=weak
+        - php: 7.1
+          env: DEPENDENCIES='dev'
+        # Test LTS version
         - php: 5.6
-          env: DEPENDENCIES='dev' SYMFONY_VERSION='2.8.*@dev'
-        - php: 5.6
-          env: SYMFONY_VERSION='2.3.*'
-        - php: 5.6
-          env: SYMFONY_VERSION='3.0.*@dev'
+          env: SYMFONY_VERSION='2.8.*'
         - php: hhvm
           dist: trusty
 
 before_install:
-    - composer self-update # remove this once the Travis upgrade of February 2015 is deployed
     - if [ "$DEPENDENCIES" == "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION}; fi;
 
-install: composer update $COMPOSER_FLAGS
+install:
+    - composer update $COMPOSER_FLAGS
+    - ./vendor/bin/simple-phpunit install
 
-script: phpunit -v
+script: ./vendor/bin/simple-phpunit -v

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/framework-bundle": "~2.3|~3.0"
     },
     "require-dev":  {
-        "symfony/phpunit-bridge": "~2.7|~3.0",
+        "symfony/phpunit-bridge": "^3.3",
         "symfony/expression-language": "~2.4|~3.0",
         "symfony/templating": "~2.3|~3.0"
     },


### PR DESCRIPTION
- use the simple-phpunit script instead of the Travis-provided phar to control the PHPUnit version
- ensure PHP 5.3 job is ready for the Travis migration to Trusty
- Clean the testing of Symfony version (no more testing of 2.8 for the dev job, and keep only LTS as explicit jobs)