### PR TITLE
Add validation of the composer.json on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,4 +41,6 @@ install:
     - composer update $COMPOSER_FLAGS
     - ./vendor/bin/simple-phpunit install
 
-script: ./vendor/bin/simple-phpunit -v
+script:
+    - composer validate --strict --no-check-lock
+    - ./vendor/bin/simple-phpunit -v


### PR DESCRIPTION
This prevents PRs breaking the validity of the composer.json, which would then be rejected by Packagist.
The lock file is not validated, as it is not committed in the repo.