### PR TITLE
Add support for autoconfiguring menu voters

### DIFF
--- a/DependencyInjection/Compiler/AddVotersPass.php
+++ b/DependencyInjection/Compiler/AddVotersPass.php
@@ -25,6 +25,10 @@ class AddVotersPass implements CompilerPassInterface
         $voters = array();
 
         foreach ($container->findTaggedServiceIds('knp_menu.voter') as $id => $tags) {
+            // Process only the first tag. Registering the same voter multiple time
+            // does not make any sense, and this allows user to overwrite the tag added
+            // by the autoconfiguration to change the priority (autoconfigured tags are
+            // always added at the end of the list).
             $tag = $tags[0];
 
             $priority = isset($tag['priority']) ? (int) $tag['priority'] : 0;

--- a/DependencyInjection/Compiler/AddVotersPass.php
+++ b/DependencyInjection/Compiler/AddVotersPass.php
@@ -25,13 +25,13 @@ class AddVotersPass implements CompilerPassInterface
         $voters = array();
 
         foreach ($container->findTaggedServiceIds('knp_menu.voter') as $id => $tags) {
-            foreach ($tags as $tag) {
-                $priority = isset($tag['priority']) ? (int) $tag['priority'] : 0;
-                $voters[$priority][] = $id;
+            $tag = $tags[0];
 
-                if (isset($tag['request']) && $tag['request']) {
-                    $listener->addMethodCall('addVoter', array(new Reference($id)));
-                }
+            $priority = isset($tag['priority']) ? (int) $tag['priority'] : 0;
+            $voters[$priority][] = $id;
+
+            if (isset($tag['request']) && $tag['request']) {
+                $listener->addMethodCall('addVoter', array(new Reference($id)));
             }
         }
 

--- a/DependencyInjection/KnpMenuExtension.php
+++ b/DependencyInjection/KnpMenuExtension.php
@@ -38,6 +38,12 @@ class KnpMenuExtension extends Extension
         }
 
         $container->setParameter('knp_menu.default_renderer', $config['default_renderer']);
+
+        // Register autoconfiguration rules for Symfony DI 3.3+
+        if (method_exists($container, 'registerForAutoconfiguration')) {
+            $container->registerForAutoconfiguration('Knp\Menu\Matcher\Voter\VoterInterface')
+                ->addTag('knp_menu.voter');
+        }
     }
 
     /**


### PR DESCRIPTION
This allows people to skip the tag `knp_menu.voter` for their VoterInterface implementations if their services are marked as autoconfigured.