### PR TITLE
First round of Symfony 4 support

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -36,7 +36,7 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->canBeUnset()
                     ->children()
-                        ->scalarNode('template')->defaultValue('KnpMenuBundle::menu.html.twig')->end()
+                        ->scalarNode('template')->defaultValue('@KnpMenu/menu.html.twig')->end()
                     ->end()
                 ->end()
                 ->booleanNode('templating')->defaultFalse()->end()

--- a/Provider/BuilderAliasProvider.php
+++ b/Provider/BuilderAliasProvider.php
@@ -99,7 +99,14 @@ class BuilderAliasProvider implements MenuProviderInterface
             $logs = array();
             $bundles = array();
 
-            foreach ($this->kernel->getBundle($bundleName, false) as  $bundle) {
+            $allBundles = $this->kernel->getBundle($bundleName, false);
+
+            // In Symfony 4, bundle inheritance is gone, so there is no way to get an array anymore.
+            if (!is_array($allBundles)) {
+                $allBundles = array($allBundles);
+            }
+
+            foreach ($allBundles as  $bundle) {
                 $try = $bundle->getNamespace().'\\Menu\\'.$className;
                 if (class_exists($try)) {
                     $class = $try;

--- a/Resources/config/menu.xml
+++ b/Resources/config/menu.xml
@@ -20,7 +20,7 @@
     </parameters>
 
     <services>
-        <service id="knp_menu.factory" class="%knp_menu.factory.class%" />
+        <service id="knp_menu.factory" class="%knp_menu.factory.class%" public="true" />
 
         <service id="knp_menu.factory_extension.routing" class="%knp_menu.factory_extension.routing.class%" public="false">
             <argument type="service" id="router" />
@@ -34,7 +34,7 @@
             <argument type="service" id="knp_menu.matcher" />
         </service>
 
-        <service id="knp_menu.matcher" class="%knp_menu.matcher.class%" />
+        <service id="knp_menu.matcher" class="%knp_menu.matcher.class%" public="true" />
 
         <service id="knp_menu.menu_provider.chain" class="%knp_menu.menu_provider.chain.class%" public="false">
             <argument type="collection" />

--- a/Tests/DependencyInjection/KnpMenuExtensionTest.php
+++ b/Tests/DependencyInjection/KnpMenuExtensionTest.php
@@ -15,7 +15,7 @@ class KnpMenuExtensionTest extends TestCase
         $loader->load(array(array()), $container);
         $this->assertTrue($container->hasDefinition('knp_menu.renderer.list'), 'The list renderer is loaded');
         $this->assertTrue($container->hasDefinition('knp_menu.renderer.twig'), 'The twig renderer is loaded');
-        $this->assertEquals('KnpMenuBundle::menu.html.twig', $container->getParameter('knp_menu.renderer.twig.template'));
+        $this->assertEquals('@KnpMenu/menu.html.twig', $container->getParameter('knp_menu.renderer.twig.template'));
         $this->assertFalse($container->hasDefinition('knp_menu.templating.helper'), 'The PHP helper is not loaded');
         $this->assertTrue($container->getDefinition('knp_menu.menu_provider.builder_alias')->hasTag('knp_menu.provider'), 'The BuilderAliasProvider is enabled');
         $this->assertTrue($container->getDefinition('knp_menu.menu_provider.container_aware')->hasTag('knp_menu.provider'), 'The ContainerAwareProvider is enabled');
@@ -27,7 +27,7 @@ class KnpMenuExtensionTest extends TestCase
         $loader = new KnpMenuExtension();
         $loader->load(array(array('twig' => true)), $container);
         $this->assertTrue($container->hasDefinition('knp_menu.renderer.twig'));
-        $this->assertEquals('KnpMenuBundle::menu.html.twig', $container->getParameter('knp_menu.renderer.twig.template'));
+        $this->assertEquals('@KnpMenu/menu.html.twig', $container->getParameter('knp_menu.renderer.twig.template'));
     }
 
     public function testOverwriteTwigTemplate()

--- a/Tests/Provider/BuilderAliasProviderTest.php
+++ b/Tests/Provider/BuilderAliasProviderTest.php
@@ -5,6 +5,7 @@ namespace Knp\Bundle\MenuBundle\Tests\Provider;
 use Knp\Bundle\MenuBundle\Provider\BuilderAliasProvider;
 use Knp\Bundle\MenuBundle\Tests\Stubs\TestKernel;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 class BuilderAliasProviderTest extends TestCase
 {
@@ -126,6 +127,10 @@ class BuilderAliasProviderTest extends TestCase
 
     public function testBundleInheritanceParent()
     {
+        if (!method_exists(BundleInterface::class, 'getParent')) {
+            $this->markTestSkipped('Bundle inheritance does not exist in this Symfony version.');
+        }
+
         $item = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
         // mock the factory to return a set value when the builder creates the menu
         $factory = $this->getMockBuilder('Knp\Menu\FactoryInterface')->getMock();
@@ -147,6 +152,10 @@ class BuilderAliasProviderTest extends TestCase
 
     public function testBundleInheritanceChild()
     {
+        if (!method_exists(BundleInterface::class, 'getParent')) {
+            $this->markTestSkipped('Bundle inheritance does not exist in this Symfony version.');
+        }
+
         $item = $this->getMockBuilder('Knp\Menu\ItemInterface')->getMock();
         // mock the factory to return a set value when the builder creates the menu
         $factory = $this->getMockBuilder('Knp\Menu\FactoryInterface')->getMock();
@@ -172,6 +181,10 @@ class BuilderAliasProviderTest extends TestCase
      */
     public function testBundleInheritanceWrongClass()
     {
+        if (!method_exists(BundleInterface::class, 'getParent')) {
+            $this->markTestSkipped('Bundle inheritance does not exist in this Symfony version.');
+        }
+
         $provider = new BuilderAliasProvider(
             $this->createTestKernel(),
             $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock(),


### PR DESCRIPTION
This starts adapting the code to prepare for Symfony 4:

- mark some services as public explicitly, to account for the change of the default visibility. Many services are not marked as public yet, because they are public only due to internal needs, which won't be needed anymore before the release.
- adapt the BuilderAliasProvider to account for the removal of bundle inheritance
- use the native Twig notation for the default template, to avoid the dependency on the templating component.