### PR TITLE
Update configuration for KnpMenu 2.3 and Symfony 3.3+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
 
 before_install:
     - if [ "$DEPENDENCIES" == "dev" ]; then composer config minimum-stability dev; fi;
-    - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/lts:${SYMFONY_VERSION}; fi;
+    - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/lts:${SYMFONY_VERSION} --no-update; fi;
 
 install:
     - composer update $COMPOSER_FLAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,13 @@ matrix:
           env: DEPENDENCIES='dev'
         # Test LTS version
         - php: 5.6
-          env: SYMFONY_VERSION='2.8.*'
+          env: SYMFONY_VERSION='^2'
         - php: 7.1
-          env: SYMFONY_VERSION='3.4.*' DEPENDENCIES='dev'
+          env: SYMFONY_VERSION='^3' DEPENDENCIES='dev'
 
 before_install:
-    - if [ "$DEPENDENCIES" == "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
-    - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION}; fi;
+    - if [ "$DEPENDENCIES" == "dev" ]; then composer config minimum-stability dev; fi;
+    - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/lts:${SYMFONY_VERSION}; fi;
 
 install:
     - composer update $COMPOSER_FLAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ php:
     - 5.6
     - 7.0
     - 7.1
+    - 7.2
     - nightly
 
 matrix:
@@ -27,12 +28,12 @@ matrix:
         # Test LTS version
         - php: 5.6
           env: SYMFONY_VERSION='2.8.*'
+        - php: 7.1
+          env: SYMFONY_VERSION='3.4.*' DEPENDENCIES='dev'
 
 before_install:
     - if [ "$DEPENDENCIES" == "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION}; fi;
-    # force the PHPUnit version for PHP 7.2, until https://github.com/symfony/symfony/issues/23943 is resolved
-    - if [ "$TRAVIS_PHP_VERSION" = "nightly" ]; then export SYMFONY_PHPUNIT_VERSION="6.3"; fi;
 
 install:
     - composer update $COMPOSER_FLAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/lts:${SYMFONY_VERSION} --no-update; fi;
 
 install:
-    - composer update $COMPOSER_FLAGS
+    - composer update $COMPOSER_FLAGS --prefer-dist
     - ./vendor/bin/simple-phpunit install
 
 script:

--- a/DependencyInjection/Compiler/AddExtensionsPass.php
+++ b/DependencyInjection/Compiler/AddExtensionsPass.php
@@ -11,6 +11,8 @@ use Symfony\Component\DependencyInjection\Reference;
  * This compiler pass registers the renderers in the RendererProvider.
  *
  * @author Christophe Coevoet <stof@notk.org>
+ *
+ * @internal
  */
 class AddExtensionsPass implements CompilerPassInterface
 {

--- a/DependencyInjection/Compiler/AddProvidersPass.php
+++ b/DependencyInjection/Compiler/AddProvidersPass.php
@@ -1,6 +1,7 @@
 <?php
 namespace Knp\Bundle\MenuBundle\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Reference;
@@ -30,6 +31,10 @@ class AddProvidersPass implements CompilerPassInterface
             // when using only one (the default case as the bundle defines one provider)
             $container->setAlias('knp_menu.menu_provider', (string) reset($providers));
         } else {
+            if (class_exists(IteratorArgument::class)) {
+                $providers = new IteratorArgument($providers);
+            }
+
             $definition = $container->getDefinition('knp_menu.menu_provider.chain');
             $definition->replaceArgument(0, $providers);
             $container->setAlias('knp_menu.menu_provider', 'knp_menu.menu_provider.chain');

--- a/DependencyInjection/Compiler/AddProvidersPass.php
+++ b/DependencyInjection/Compiler/AddProvidersPass.php
@@ -9,6 +9,8 @@ use Symfony\Component\DependencyInjection\Reference;
  * This compiler pass registers the providers in the ChainProvider.
  *
  * @author Christophe Coevoet <stof@notk.org>
+ *
+ * @internal
  */
 class AddProvidersPass implements CompilerPassInterface
 {

--- a/DependencyInjection/Compiler/AddRenderersPass.php
+++ b/DependencyInjection/Compiler/AddRenderersPass.php
@@ -8,6 +8,8 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
  * This compiler pass registers the renderers in the RendererProvider.
  *
  * @author Christophe Coevoet <stof@notk.org>
+ *
+ * @internal
  */
 class AddRenderersPass implements CompilerPassInterface
 {

--- a/DependencyInjection/Compiler/AddRenderersPass.php
+++ b/DependencyInjection/Compiler/AddRenderersPass.php
@@ -1,8 +1,11 @@
 <?php
 namespace Knp\Bundle\MenuBundle\DependencyInjection\Compiler;
 
+use Knp\Menu\Renderer\PsrProvider;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * This compiler pass registers the renderers in the RendererProvider.
@@ -18,17 +21,30 @@ class AddRenderersPass implements CompilerPassInterface
         if (!$container->hasDefinition('knp_menu.renderer_provider')) {
             return;
         }
-        $definition = $container->getDefinition('knp_menu.renderer_provider');
 
         $renderers = array();
-        foreach ($container->findTaggedServiceIds('knp_menu.renderer') as $id => $tags) {
+        $rendererReferences = array();
+
+        foreach ($container->findTaggedServiceIds('knp_menu.renderer', true) as $id => $tags) {
             foreach ($tags as $attributes) {
                 if (empty($attributes['alias'])) {
                     throw new \InvalidArgumentException(sprintf('The alias is not defined in the "knp_menu.renderer" tag for the service "%s"', $id));
                 }
                 $renderers[$attributes['alias']] = $id;
+                $rendererReferences[$attributes['alias']] = new Reference($id);
             }
         }
-        $definition->replaceArgument(2, $renderers);
+
+        if (class_exists(ServiceLocatorTagPass::class)) {
+            $locator = ServiceLocatorTagPass::register($container, $rendererReferences);
+            // Replace the service definition with a PsrProvider
+            $container->register('knp_menu.renderer_provider', PsrProvider::class)
+                ->addArgument($locator)
+                ->addArgument('%knp_menu.default_renderer%');
+        } else {
+            // BC for Symfony < 3.3
+            $definition = $container->getDefinition('knp_menu.renderer_provider');
+            $definition->replaceArgument(2, $renderers);
+        }
     }
 }

--- a/DependencyInjection/Compiler/AddTemplatePathPass.php
+++ b/DependencyInjection/Compiler/AddTemplatePathPass.php
@@ -8,6 +8,8 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
  * This compiler pass adds the path for the KnpMenu template in the twig loader.
  *
  * @author Christophe Coevoet <stof@notk.org>
+ *
+ * @internal
  */
 class AddTemplatePathPass implements CompilerPassInterface
 {

--- a/DependencyInjection/Compiler/AddVotersPass.php
+++ b/DependencyInjection/Compiler/AddVotersPass.php
@@ -11,6 +11,8 @@ use Symfony\Component\DependencyInjection\Reference;
  * This compiler pass registers the voters in the Matcher.
  *
  * @author Christophe Coevoet <stof@notk.org>
+ *
+ * @internal
  */
 class AddVotersPass implements CompilerPassInterface
 {

--- a/DependencyInjection/Compiler/AddVotersPass.php
+++ b/DependencyInjection/Compiler/AddVotersPass.php
@@ -2,12 +2,13 @@
 
 namespace Knp\Bundle\MenuBundle\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * This compiler pass registers the renderers in the RendererProvider.
+ * This compiler pass registers the voters in the Matcher.
  *
  * @author Christophe Coevoet <stof@notk.org>
  */
@@ -22,6 +23,8 @@ class AddVotersPass implements CompilerPassInterface
         $definition = $container->getDefinition('knp_menu.matcher');
         $listener = $container->getDefinition('knp_menu.listener.voters');
 
+        $hasRequestAwareVoter = false;
+
         $voters = array();
 
         foreach ($container->findTaggedServiceIds('knp_menu.voter') as $id => $tags) {
@@ -32,11 +35,17 @@ class AddVotersPass implements CompilerPassInterface
             $tag = $tags[0];
 
             $priority = isset($tag['priority']) ? (int) $tag['priority'] : 0;
-            $voters[$priority][] = $id;
+            $voters[$priority][] = new Reference($id);
 
             if (isset($tag['request']) && $tag['request']) {
+                @trigger_error('Using the "request" attribute of the "knp_menu.voter" tag is deprecated since version 2.2. Inject the RequestStack in the voter instead.', E_USER_DEPRECATED);
+                $hasRequestAwareVoter = true;
                 $listener->addMethodCall('addVoter', array(new Reference($id)));
             }
+        }
+
+        if (!$hasRequestAwareVoter) {
+            $container->removeDefinition('knp_menu.listener.voters');
         }
 
         if (empty($voters)) {
@@ -46,8 +55,11 @@ class AddVotersPass implements CompilerPassInterface
         krsort($voters);
         $sortedVoters = call_user_func_array('array_merge', $voters);
 
-        foreach ($sortedVoters as $id) {
-            $definition->addMethodCall('addVoter', array(new Reference($id)));
+        if (class_exists(IteratorArgument::class)) {
+            $definition->replaceArgument(0, new IteratorArgument($sortedVoters));
+        } else {
+            // BC layer for Symfony DI < 3.3
+            $definition->replaceArgument(0, $sortedVoters);
         }
     }
 }

--- a/DependencyInjection/Compiler/MenuBuilderPass.php
+++ b/DependencyInjection/Compiler/MenuBuilderPass.php
@@ -16,6 +16,10 @@ class MenuBuilderPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
+        if (!$container->hasDefinition('knp_menu.menu_provider.builder_service')) {
+            return;
+        }
+
         $definition = $container->getDefinition('knp_menu.menu_provider.builder_service');
 
         $menuBuilders = array();

--- a/DependencyInjection/Compiler/MenuBuilderPass.php
+++ b/DependencyInjection/Compiler/MenuBuilderPass.php
@@ -9,6 +9,8 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
  * This compiler pass registers the menu builders in the BuilderServiceProvider.
  *
  * @author Christophe Coevoet <stof@notk.org>
+ *
+ * @internal
  */
 class MenuBuilderPass implements CompilerPassInterface
 {

--- a/DependencyInjection/Compiler/MenuPass.php
+++ b/DependencyInjection/Compiler/MenuPass.php
@@ -4,6 +4,9 @@ namespace Knp\Bundle\MenuBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 
+/**
+ * @internal
+ */
 class MenuPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)

--- a/DependencyInjection/Compiler/RegisterMenusPass.php
+++ b/DependencyInjection/Compiler/RegisterMenusPass.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Knp\Bundle\MenuBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * This compiler pass registers the menu builders in the LazyProvider.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ *
+ * @internal
+ */
+class RegisterMenusPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('knp_menu.menu_provider.lazy')) {
+            return;
+        }
+
+        // When using Symfony < 3.3, the LazyProvider cannot be used (at least not in a lazy way)
+        // so the older providers will be used.
+        if (!class_exists(ServiceClosureArgument::class)) {
+            $container->removeDefinition('knp_menu.menu_provider.lazy');
+
+            return;
+        }
+
+        // Remove the old way of handling this feature.
+        $container->removeDefinition('knp_menu.menu_provider.container_aware');
+        $container->removeDefinition('knp_menu.menu_provider.builder_service');
+
+        $menuBuilders = array();
+        foreach ($container->findTaggedServiceIds('knp_menu.menu_builder', true) as $id => $tags) {
+            foreach ($tags as $attributes) {
+                if (empty($attributes['alias'])) {
+                    throw new \InvalidArgumentException(sprintf('The alias is not defined in the "knp_menu.menu_builder" tag for the service "%s"', $id));
+                }
+                if (empty($attributes['method'])) {
+                    throw new \InvalidArgumentException(sprintf('The method is not defined in the "knp_menu.menu_builder" tag for the service "%s"', $id));
+                }
+                $menuBuilders[$attributes['alias']] = array(new ServiceClosureArgument(new Reference($id)), $attributes['method']);
+            }
+        }
+
+        foreach ($container->findTaggedServiceIds('knp_menu.menu', true) as $id => $tags) {
+            foreach ($tags as $attributes) {
+                if (empty($attributes['alias'])) {
+                    throw new \InvalidArgumentException(sprintf('The alias is not defined in the "knp_menu.menu" tag for the service "%s"', $id));
+                }
+                $menuBuilders[$attributes['alias']] = new ServiceClosureArgument(new Reference($id));
+            }
+        }
+
+        $container->getDefinition('knp_menu.menu_provider.lazy')->replaceArgument(0, $menuBuilders);
+    }
+}

--- a/EventListener/VoterInitializerListener.php
+++ b/EventListener/VoterInitializerListener.php
@@ -2,6 +2,8 @@
 
 namespace Knp\Bundle\MenuBundle\EventListener;
 
+@trigger_error(sprintf('The %s class is deprecated since 2.2 and will be removed in 3.0.', VoterInitializerListener::class), E_USER_DEPRECATED);
+
 use Knp\Menu\Matcher\Voter\VoterInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;

--- a/KnpMenuBundle.php
+++ b/KnpMenuBundle.php
@@ -9,6 +9,7 @@ use Knp\Bundle\MenuBundle\DependencyInjection\Compiler\AddTemplatePathPass;
 use Knp\Bundle\MenuBundle\DependencyInjection\Compiler\AddVotersPass;
 use Knp\Bundle\MenuBundle\DependencyInjection\Compiler\MenuBuilderPass;
 use Knp\Bundle\MenuBundle\DependencyInjection\Compiler\MenuPass;
+use Knp\Bundle\MenuBundle\DependencyInjection\Compiler\RegisterMenusPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -18,6 +19,7 @@ class KnpMenuBundle extends Bundle
     {
         parent::build($container);
 
+        $container->addCompilerPass(new RegisterMenusPass());
         $container->addCompilerPass(new MenuPass());
         $container->addCompilerPass(new MenuBuilderPass());
         $container->addCompilerPass(new AddExtensionsPass());

--- a/Renderer/ContainerAwareProvider.php
+++ b/Renderer/ContainerAwareProvider.php
@@ -5,17 +5,24 @@ namespace Knp\Bundle\MenuBundle\Renderer;
 use Knp\Menu\Renderer\RendererProviderInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/**
+ * @deprecated since version 2.2. Use "Knp\Menu\Renderer\PsrProvider" instead.
+ */
 class ContainerAwareProvider implements RendererProviderInterface
 {
     private $container;
     private $rendererIds;
     private $defaultRenderer;
 
-    public function __construct(ContainerInterface $container, $defaultRenderer, array $rendererIds)
+    public function __construct(ContainerInterface $container, $defaultRenderer, array $rendererIds, $triggerDeprecation = true)
     {
         $this->container = $container;
         $this->rendererIds = $rendererIds;
         $this->defaultRenderer = $defaultRenderer;
+
+        if ($triggerDeprecation) {
+            @trigger_error(sprintf('The %s class is deprecated since 2.2 and will be removed in 3.0. USe "Knp\Menu\Renderer\PsrProvider" instead.', __CLASS__),E_USER_DEPRECATED);
+        }
     }
 
     public function get($name = null)

--- a/Resources/config/menu.xml
+++ b/Resources/config/menu.xml
@@ -42,6 +42,11 @@
             <argument type="collection" />
         </service>
 
+        <service id="knp_menu.menu_provider.lazy" class="Knp\Menu\Provider\LazyProvider" public="false">
+            <argument type="collection" />
+            <tag name="knp_menu.provider" />
+        </service>
+
         <service id="knp_menu.menu_provider.container_aware" class="%knp_menu.menu_provider.container_aware.class%" public="false">
             <argument type="service" id="service_container" />
             <argument type="collection" />

--- a/Resources/config/menu.xml
+++ b/Resources/config/menu.xml
@@ -62,6 +62,7 @@
             <argument type="service" id="service_container" />
             <argument>%knp_menu.default_renderer%</argument>
             <argument type="collection" />
+            <argument>false</argument>
         </service>
 
         <service id="knp_menu.renderer.list" class="%knp_menu.renderer.list.class%">

--- a/Resources/config/menu.xml
+++ b/Resources/config/menu.xml
@@ -34,7 +34,9 @@
             <argument type="service" id="knp_menu.matcher" />
         </service>
 
-        <service id="knp_menu.matcher" class="%knp_menu.matcher.class%" public="true" />
+        <service id="knp_menu.matcher" class="%knp_menu.matcher.class%" public="true">
+            <argument type="collection" />
+        </service>
 
         <service id="knp_menu.menu_provider.chain" class="%knp_menu.menu_provider.chain.class%" public="false">
             <argument type="collection" />
@@ -74,7 +76,8 @@
         </service>
 
         <service id="knp_menu.voter.router" class="%knp_menu.voter.router.class%">
-            <tag name="knp_menu.voter" request="true" />
+            <argument type="service" id="request_stack" />
+            <tag name="knp_menu.voter" />
         </service>
 
         <service id="knp_menu.manipulator" class="Knp\Menu\Util\MenuManipulator" public="false" />

--- a/Tests/DependencyInjection/Compiler/AddProvidersPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddProvidersPassTest.php
@@ -4,6 +4,8 @@ namespace Knp\Bundle\MenuBundle\Tests\DependencyInjection\Compiler;
 
 use Knp\Bundle\MenuBundle\DependencyInjection\Compiler\AddProvidersPass;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Reference;
 
 class AddProvidersPassTest extends TestCase
 {
@@ -44,12 +46,18 @@ class AddProvidersPassTest extends TestCase
 
     public function testProcessForManyProviders()
     {
+        $expectedProviders = array(new Reference('id'), new Reference('id2'));
+
+        if (class_exists(IteratorArgument::class)) {
+            $expectedProviders = new IteratorArgument($expectedProviders);
+        }
+
         $definitionMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')
             ->disableOriginalConstructor()
             ->getMock();
         $definitionMock->expects($this->once())
             ->method('replaceArgument')
-            ->with($this->equalTo(0), $this->isType('array'));
+            ->with($this->equalTo(0), $expectedProviders);
 
         $containerBuilderMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->getMock();
         $containerBuilderMock->expects($this->once())

--- a/Tests/DependencyInjection/Compiler/MenuBuilderPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MenuBuilderPassTest.php
@@ -23,11 +23,21 @@ class MenuBuilderPassTest extends TestCase
         $this->builderDefinition = $this->prophesize('Symfony\Component\DependencyInjection\Definition');
         $this->pass = new MenuBuilderPass();
 
+        $this->containerBuilder->hasDefinition('knp_menu.menu_provider.builder_service')->willReturn(true);
         $this->containerBuilder->getDefinition('knp_menu.menu_provider.builder_service')->willReturn($this->definition);
         $this->containerBuilder->getDefinition('id')->willReturn($this->builderDefinition);
 
         $this->builderDefinition->isPublic()->willReturn(true);
         $this->builderDefinition->isAbstract()->willReturn(false);
+    }
+
+    public function testNoopWithoutProvider()
+    {
+        $this->containerBuilder->hasDefinition('knp_menu.menu_provider.builder_service')->willReturn(false);
+
+        $this->containerBuilder->findTaggedServiceIds('knp_menu.menu_builder')->shouldNotBeCalled();
+
+        $this->pass->process($this->containerBuilder->reveal());
     }
 
     /**

--- a/Tests/DependencyInjection/Compiler/RegisterMenusPassTest.php
+++ b/Tests/DependencyInjection/Compiler/RegisterMenusPassTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Knp\Bundle\MenuBundle\Tests\DependencyInjection\Compiler;
+
+use Knp\Bundle\MenuBundle\DependencyInjection\Compiler\RegisterMenusPass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class RegisterMenusPassTest extends TestCase
+{
+    private $containerBuilder;
+    private $definition;
+
+    /**
+     * @var RegisterMenusPass
+     */
+    private $pass;
+
+    protected function setUp()
+    {
+        if (!class_exists(ServiceClosureArgument::class)) {
+            $this->markTestSkipped('The RegisterMenuPass requires Symfony DI 3.3+.');
+        }
+
+        $this->containerBuilder = $this->prophesize(ContainerBuilder::class);
+        $this->definition = $this->prophesize(Definition::class);
+        $this->pass = new RegisterMenusPass();
+
+        $this->containerBuilder->hasDefinition('knp_menu.menu_provider.lazy')->willReturn(true);
+        $this->containerBuilder->getDefinition('knp_menu.menu_provider.lazy')->willReturn($this->definition);
+
+        $this->containerBuilder->removeDefinition('knp_menu.menu_provider.container_aware')->shouldBeCalled();
+        $this->containerBuilder->removeDefinition('knp_menu.menu_provider.builder_service')->shouldBeCalled();
+
+        $this->containerBuilder->findTaggedServiceIds('knp_menu.menu_builder', true)->willReturn(array());
+        $this->containerBuilder->findTaggedServiceIds('knp_menu.menu', true)->willReturn(array());
+    }
+
+    public function testNoopWithoutProvider()
+    {
+        $this->containerBuilder->hasDefinition('knp_menu.menu_provider.lazy')->willReturn(false);
+
+        $this->containerBuilder->findTaggedServiceIds('knp_menu.menu_builder', true)->shouldNotBeCalled();
+        $this->containerBuilder->findTaggedServiceIds('knp_menu.menu', true)->shouldNotBeCalled();
+        $this->containerBuilder->removeDefinition('knp_menu.menu_provider.container_aware')->shouldNotBeCalled();
+        $this->containerBuilder->removeDefinition('knp_menu.menu_provider.builder_service')->shouldNotBeCalled();
+
+        $this->pass->process($this->containerBuilder->reveal());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The alias is not defined in the "knp_menu.menu_builder" tag for the service "id"
+     */
+    public function testFailsWhenBuilderAliasIsMissing()
+    {
+        $this->containerBuilder->findTaggedServiceIds('knp_menu.menu_builder', true)->willReturn(array('id' => array(array('alias' => ''))));
+
+        $this->pass->process($this->containerBuilder->reveal());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The method is not defined in the "knp_menu.menu_builder" tag for the service "id"
+     */
+    public function testFailsWhenBuilderMethodIsMissing()
+    {
+        $this->containerBuilder->findTaggedServiceIds('knp_menu.menu_builder', true)->willReturn(array('id' => array(array('alias' => 'foo'))));
+
+        $this->pass->process($this->containerBuilder->reveal());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The alias is not defined in the "knp_menu.menu" tag for the service "id"
+     */
+    public function testFailsWhenMenuAliasIsMissing()
+    {
+        $this->containerBuilder->findTaggedServiceIds('knp_menu.menu', true)->willReturn(array('id' => array(array('alias' => ''))));
+
+        $this->pass->process($this->containerBuilder->reveal());
+    }
+
+    public function testRegisterMenuBuilderAndMenu()
+    {
+        $this->containerBuilder->findTaggedServiceIds('knp_menu.menu_builder', true)->willReturn(array(
+            'id1' => array(array('alias' => 'foo', 'method' => 'fooMenu'), array('alias' => 'bar', 'method' => 'bar')),
+            'id2' => array(array('alias' => 'foo', 'method' => 'fooBar'), array('alias' => 'baz', 'method' => 'bar')),
+        ));
+        $this->containerBuilder->findTaggedServiceIds('knp_menu.menu', true)->willReturn(array('id3' => array(array('alias' => 'test'))));
+
+        $menus = array(
+            'foo' => array(new ServiceClosureArgument(new Reference('id2')), 'fooBar'),
+            'bar' => array(new ServiceClosureArgument(new Reference('id1')), 'bar'),
+            'baz' => array(new ServiceClosureArgument(new Reference('id2')), 'bar'),
+            'test' => new ServiceClosureArgument(new Reference('id3')),
+        );
+        $this->definition->replaceArgument(0, $menus)->shouldBeCalled();
+
+        $this->pass->process($this->containerBuilder->reveal());
+    }
+
+    public function testMenuWinsOverBuilder()
+    {
+        $this->containerBuilder->findTaggedServiceIds('knp_menu.menu_builder', true)->willReturn(array(
+            'id1' => array(array('alias' => 'foo', 'method' => 'fooMenu'), array('alias' => 'bar', 'method' => 'bar')),
+        ));
+        $this->containerBuilder->findTaggedServiceIds('knp_menu.menu', true)->willReturn(array('id3' => array(array('alias' => 'foo'))));
+
+        $menus = array(
+            'foo' => new ServiceClosureArgument(new Reference('id3')),
+            'bar' => array(new ServiceClosureArgument(new Reference('id1')), 'bar'),
+        );
+        $this->definition->replaceArgument(0, $menus)->shouldBeCalled();
+
+        $this->pass->process($this->containerBuilder->reveal());
+
+    }
+}

--- a/Tests/EventListener/VoterInitializerListenerTest.php
+++ b/Tests/EventListener/VoterInitializerListenerTest.php
@@ -7,6 +7,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
+/**
+ * @group legacy
+ */
 class VoterInitializerListenerTest extends TestCase
 {
     public function testHandleSubRequest()

--- a/Tests/Provider/BuilderAliasProviderTest.php
+++ b/Tests/Provider/BuilderAliasProviderTest.php
@@ -79,7 +79,7 @@ class BuilderAliasProviderTest extends TestCase
             $this->getMockBuilder('Knp\Menu\FactoryInterface')->getMock()
         );
 
-        $menu = $provider->get('FooBundle:Builder:invalidMethod');
+        $provider->get('FooBundle:Builder:invalidMethod');
     }
 
     /**
@@ -125,6 +125,9 @@ class BuilderAliasProviderTest extends TestCase
         $provider->get('FooBundle:Builder:fakeMenu');
     }
 
+    /**
+     * @group legacy
+     */
     public function testBundleInheritanceParent()
     {
         if (!method_exists(BundleInterface::class, 'getParent')) {
@@ -150,6 +153,9 @@ class BuilderAliasProviderTest extends TestCase
         $this->assertSame($item, $menu);
     }
 
+    /**
+     * @group legacy
+     */
     public function testBundleInheritanceChild()
     {
         if (!method_exists(BundleInterface::class, 'getParent')) {
@@ -178,6 +184,7 @@ class BuilderAliasProviderTest extends TestCase
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Unable to find menu builder "FooBundle:Fake" in bundles BarBundle, FooBundle.
+     * @group legacy
      */
     public function testBundleInheritanceWrongClass()
     {

--- a/Tests/Renderer/ContainerAwareProviderTest.php
+++ b/Tests/Renderer/ContainerAwareProviderTest.php
@@ -5,6 +5,9 @@ namespace Knp\Bundle\MenuBundle\Tests\Renderer;
 use Knp\Bundle\MenuBundle\Renderer\ContainerAwareProvider;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group legacy
+ */
 class ContainerAwareProviderTest extends TestCase
 {
     public function testHas()

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require":      {
         "php": "^5.6 || ^7",
-        "knplabs/knp-menu":         "~2.2",
+        "knplabs/knp-menu":         "~2.3@dev",
         "symfony/framework-bundle": "~2.7|~3.0"
     },
     "require-dev":  {

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
     "require":      {
         "php": "^5.6 || ^7",
         "knplabs/knp-menu":         "~2.3@dev",
-        "symfony/framework-bundle": "~2.7|~3.0"
+        "symfony/framework-bundle": "~2.7|~3.0 | ^4.0"
     },
     "require-dev":  {
-        "symfony/phpunit-bridge": "^3.3",
-        "symfony/expression-language": "~2.7|~3.0",
-        "symfony/templating": "~2.7|~3.0"
+        "symfony/phpunit-bridge": "^3.3 | ^4.0",
+        "symfony/expression-language": "~2.7|~3.0 | ^4.0",
+        "symfony/templating": "~2.7|~3.0 | ^4.0"
     },
     "autoload":     {
         "psr-4": { "Knp\\Bundle\\MenuBundle\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require":      {
         "php": "^5.6 || ^7",
-        "knplabs/knp-menu":         "~2.3@dev",
+        "knplabs/knp-menu": "~2.3",
         "symfony/framework-bundle": "~2.7|~3.0 | ^4.0"
     },
     "require-dev":  {


### PR DESCRIPTION
This PR uses all the new features I added recently to benefit from Symfony 3.3 DI features (allowing to keep menu builders and menus as private services for instance).

Support for older Symfony versions is kept (I want to have at least 1 release of the bundle compatible with the 2.x LTS and supporting KnpMenu 2.3 without deprecations), but support for private services in these places is not available in this case.

Each commit performs a different refactoring, so things are easier to review commit by commit (I could have split these into multiple PRs, but it was harder for me as I was in the train)