### PR TITLE
SF4 support

### DIFF
--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -17,7 +17,7 @@
             <argument type="service" id="knp_menu.manipulator" />
         </service>
 
-        <service id="knp_menu.renderer.twig" class="%knp_menu.renderer.twig.class%">
+        <service id="knp_menu.renderer.twig" class="%knp_menu.renderer.twig.class%" public="true">
             <tag name="knp_menu.renderer" alias="twig" />
             <argument type="service" id="twig" />
             <argument>%knp_menu.renderer.twig.template%</argument>


### PR DESCRIPTION
The "knp_menu.renderer.twig" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.