### PR TITLE
Fix deprecation notice on Symfony 3.4 and higher, assuring BC

### DIFF
--- a/src/Provider/BuilderAliasProvider.php
+++ b/src/Provider/BuilderAliasProvider.php
@@ -8,6 +8,7 @@ use Knp\Menu\Provider\MenuProviderInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * A menu provider that allows for an AcmeBundle:Builder:mainMenu shortcut syntax
@@ -16,6 +17,8 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 class BuilderAliasProvider implements MenuProviderInterface
 {
+    const VERSION_DEPRECATION = 34;
+
     private $kernel;
 
     private $container;
@@ -101,7 +104,13 @@ class BuilderAliasProvider implements MenuProviderInterface
             $logs = array();
             $bundles = array();
 
-            $allBundles = $this->kernel->getBundle($bundleName, false);
+            // Fix deprecation notice on Symfony 3.4 and higher, assuring BC
+            $version = Kernel::MAJOR_VERSION.Kernel::MINOR_VERSION;
+            if ($version >= $this::VERSION_DEPRECATION) {
+                $allBundles = $this->kernel->getBundle($bundleName);
+            } else {
+                $allBundles = $this->kernel->getBundle($bundleName, false);
+            }
 
             // In Symfony 4, bundle inheritance is gone, so there is no way to get an array anymore.
             if (!is_array($allBundles)) {

--- a/tests/Provider/BuilderAliasProviderTest.php
+++ b/tests/Provider/BuilderAliasProviderTest.php
@@ -6,6 +6,7 @@ use Knp\Bundle\MenuBundle\Provider\BuilderAliasProvider;
 use Knp\Bundle\MenuBundle\Tests\Stubs\TestKernel;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 class BuilderAliasProviderTest extends TestCase
 {
@@ -218,11 +219,21 @@ class BuilderAliasProviderTest extends TestCase
         ;
 
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
-        $kernel->expects($this->once())
-            ->method('getBundle')
-            ->with('FooBundle', false)
-            ->will($this->returnValue(array($bundle)))
-        ;
+        // Fix deprecation notice on Symfony 3.4 and higher, assuring BC
+        $version = Kernel::MAJOR_VERSION.Kernel::MINOR_VERSION;
+        if ($version >= BuilderAliasProvider::VERSION_DEPRECATION) {
+            $kernel->expects($this->once())
+                ->method('getBundle')
+                ->with('FooBundle')
+                ->will($this->returnValue(array($bundle)))
+            ;
+        } else {
+            $kernel->expects($this->once())
+                ->method('getBundle')
+                ->with('FooBundle', false)
+                ->will($this->returnValue(array($bundle)))
+            ;
+        }
 
         return $kernel;
     }


### PR DESCRIPTION
Since passing "false" as the second argument to Symfony\Component\HttpKernel\Kernel::getBundle() is deprecated as of 3.4 and will be removed in 4.0, I did a small version verification, to assure backwards compatibility.
I am aware of the discussion in issue #375.
 
Is this solution good enough for your standards?