### PR TITLE
Implement a MenuBuilderProviderInterface to support autoconfiguration

### DIFF
--- a/src/DependencyInjection/KnpMenuExtension.php
+++ b/src/DependencyInjection/KnpMenuExtension.php
@@ -2,6 +2,7 @@
 
 namespace Knp\Bundle\MenuBundle\DependencyInjection;
 
+use Knp\Bundle\MenuBundle\MenuBuilderProviderInterface;
 use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\Voter\VoterInterface;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -46,6 +47,8 @@ class KnpMenuExtension extends Extension implements PrependExtensionInterface
         if (method_exists($container, 'registerForAutoconfiguration')) {
             $container->registerForAutoconfiguration(VoterInterface::class)
                 ->addTag('knp_menu.voter');
+            $container->registerForAutoconfiguration(MenuBuilderProviderInterface::class)
+                ->addTag('knp_menu.menu_builder_provider');
         }
     }
 

--- a/src/MenuBuilderProviderInterface.php
+++ b/src/MenuBuilderProviderInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Knp\Bundle\MenuBundle;
+
+interface MenuBuilderProviderInterface
+{
+    /**
+     * Gets the list of menu builders provided by this class.
+     *
+     * The return value is a map of "menu name" => "builder method".
+     * The builder method must be a public method. It will receive the
+     * array of options as first argument.
+     *
+     * @return array
+     */
+    public static function getMenuBuilders();
+}

--- a/src/Resources/doc/menu_builder_service.rst
+++ b/src/Resources/doc/menu_builder_service.rst
@@ -1,6 +1,12 @@
 Creating Menu Builders as Services
 ==================================
 
+.. note::
+
+    Registering menu builders as services without using the ``MenuBuilderProviderInterface``
+    means that the registration of services will live in your config file
+    rather than in the code. Other than that, things are exactly the same.
+
 This bundle gives you a really convenient way to create menus by following
 a convention and - if needed - injecting the entire container.
 
@@ -63,8 +69,9 @@ Next, register your menu builder as service and register its ``createMainMenu`` 
 
 .. note::
 
-    The menu service must be public as it will be retrieved at runtime to keep
-    it lazy-loaded.
+    When using Symfony 3.2 or older, the menu service must be public as it
+    will be retrieved at runtime to keep it lazy-loaded. On Symfony 3.3+,
+    private services are supported.
 
 You can now render the menu directly in a template via the name given in the
 ``alias`` key above:

--- a/src/Resources/doc/menu_convention.rst
+++ b/src/Resources/doc/menu_convention.rst
@@ -1,0 +1,110 @@
+Convention-based menus
+======================
+
+For apps using bundles, menus can be defined using a special convention
+instead of registering them as services.
+
+.. note::
+
+    For projects not using a bundle (Flex projects for instance), this
+    way of defining menus does not work. Register your builders as services
+    instead.
+
+To create a menu, first create a new class in the ``Menu`` directory of one
+of your bundles. This class - called ``Builder`` in our example - will have
+one method for each menu that you need to build.
+
+An example builder class would look like this:
+
+.. code-block:: php
+
+    // src/AppBundle/Menu/Builder.php
+    namespace AppBundle\Menu;
+
+    use Knp\Menu\FactoryInterface;
+    use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+    use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+    class Builder implements ContainerAwareInterface
+    {
+        use ContainerAwareTrait;
+
+        public function mainMenu(FactoryInterface $factory, array $options)
+        {
+            $menu = $factory->createItem('root');
+
+            $menu->addChild('Home', ['route' => 'homepage']);
+
+            // access services from the container!
+            $em = $this->container->get('doctrine')->getManager();
+            // findMostRecent and Blog are just imaginary examples
+            $blog = $em->getRepository('AppBundle:Blog')->findMostRecent();
+
+            $menu->addChild('Latest Blog Post', [
+                'route' => 'blog_show',
+                'routeParameters' => ['id' => $blog->getId()]
+            ]);
+
+            // create another menu item
+            $menu->addChild('About Me', ['route' => 'about']);
+            // you can also add sub levels to your menus as follows
+            $menu['About Me']->addChild('Edit profile', ['route' => 'edit_profile']);
+
+            // ... add more children
+
+            return $menu;
+        }
+    }
+
+With the standard ``knp_menu.html.twig`` template and your current page being
+'Home', your menu would render with the following markup:
+
+.. code-block:: html
+
+    <ul>
+        <li class="current first">
+            <a href="#route_to/homepage">Home</a>
+        </li>
+        <li class="current_ancestor">
+            <a href="#route_to/page_show/?id=42">About Me</a>
+            <ul class="menu_level_1">
+                <li class="current first last">
+                    <a href="#route_to/edit_profile">Edit profile</a>
+                </li>
+            </ul>
+        </li>
+    </ul>
+
+.. note::
+
+    You only need to implement ``ContainerAwareInterface`` if you need the
+    service container. The more elegant way to handle your dependencies is to
+    inject them in the constructor. If you want to do that, see method below.
+
+.. note::
+
+    The menu builder can be overwritten using the bundle inheritance.
+
+To actually render the menu, just do the following from anywhere in any template:
+
+.. configuration-block::
+
+    .. code-block:: html+jinja
+
+        {{ knp_menu_render('AppBundle:Builder:mainMenu') }}
+
+    .. code-block:: html+php
+
+        <?php echo $view['knp_menu']->render('AppBundle:Builder:mainMenu') ?>
+
+With this method, you refer to the menu using a three-part string:
+**bundle**:**class**:**method**.
+
+If you needed to create a second menu, you'd simply add another method to
+the ``Builder`` class (e.g. ``sidebarMenu``), build and return the new menu,
+then render it via ``AppBundle:Builder:sidebarMenu``.
+
+That's it! The menu is *very* configurable. For more details, see the
+`KnpMenu documentation`_.
+
+.. _`KnpMenu documentation`: https://github.com/KnpLabs/KnpMenu/blob/master/doc/01-Basic-Menus.markdown


### PR DESCRIPTION
This interface allows defining the menu names from the class itself instead of having to define them in the service definition. This is similar to the event subscriber vs event listener system in Symfony.
The benefit of this interface is that the service definition can rely on autoconfiguration to register everything, which fits very well with the Flex way.

TODOs:
- [ ] write tests