### PR TITLE
Don't use the deprecated interface with Symfony 4.2

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -19,8 +19,14 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('knp_menu');
+        $treeBuilder = new TreeBuilder('knp_menu');
+
+        // Keep compatibility with symfony/config < 4.2
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('knp_menu');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
As there is no update to #396 I'm creating a new PR instead.