### PR TITLE
Add a priority to allow controlling the order of providers

### DIFF
--- a/src/DependencyInjection/Compiler/AddProvidersPass.php
+++ b/src/DependencyInjection/Compiler/AddProvidersPass.php
@@ -1,6 +1,8 @@
 <?php
 namespace Knp\Bundle\MenuBundle\DependencyInjection\Compiler;
 
+use function call_user_func_array;
+use function krsort;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -23,20 +25,30 @@ class AddProvidersPass implements CompilerPassInterface
 
         $providers = [];
         foreach ($container->findTaggedServiceIds('knp_menu.provider') as $id => $tags) {
-            $providers[] = new Reference($id);
+            // Process only the first tag. Registering the same provider multiple time
+            // does not make any sense, and this allows user to overwrite the tag added
+            // by the autoconfiguration to change the priority (autoconfigured tags are
+            // always added at the end of the list).
+            $tag = $tags[0];
+
+            $priority = isset($tag['priority']) ? (int) $tag['priority'] : 0;
+            $providers[$priority][] = new Reference($id);
         }
 
-        if (1 === count($providers)) {
+        krsort($providers);
+        $sortedProviders = call_user_func_array('array_merge', $providers);
+
+        if (1 === count($sortedProviders)) {
             // Use an alias instead of wrapping it in the ChainProvider for performances
             // when using only one (the default case as the bundle defines one provider)
-            $container->setAlias('knp_menu.menu_provider', (string) reset($providers));
+            $container->setAlias('knp_menu.menu_provider', (string) reset($sortedProviders));
         } else {
             if (class_exists(IteratorArgument::class)) {
-                $providers = new IteratorArgument($providers);
+                $sortedProviders = new IteratorArgument($sortedProviders);
             }
 
             $definition = $container->getDefinition('knp_menu.menu_provider.chain');
-            $definition->replaceArgument(0, $providers);
+            $definition->replaceArgument(0, $sortedProviders);
             $container->setAlias('knp_menu.menu_provider', 'knp_menu.menu_provider.chain');
         }
     }


### PR DESCRIPTION
This Pull Request introduce a new feature to allow specifying the priority of providers during the registration of a new provider when this one has been tagged. (Similar has voters)

So, a developer will now be able to write something like:
```yaml
services:
  app.menu_provider:
        class: AppBundle\Provider\CustomMenuProvider
        arguments:
          - @knp_menu.factory
        tags:
          - { name: knp_menu.provider, priority: 20 }
```