### PR TITLE
enforce Symfony coding standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.*.cache
 composer.lock
 vendor/*

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,17 @@
+<?php
+// see https://github.com/FriendsOfPHP/PHP-CS-Fixer
+
+$finder = PhpCsFixer\Finder::create()
+    ->exclude('vendor')
+    ->in([__DIR__])
+;
+
+return PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+        'array_syntax' => ['syntax' => 'short'],
+    ])
+    ->setFinder($finder)
+;

--- a/src/DependencyInjection/Compiler/AddExtensionsPass.php
+++ b/src/DependencyInjection/Compiler/AddExtensionsPass.php
@@ -23,7 +23,7 @@ class AddExtensionsPass implements CompilerPassInterface
         }
 
         $taggedServiceIds = $container->findTaggedServiceIds('knp_menu.factory_extension');
-        if (0 === count($taggedServiceIds)) {
+        if (0 === \count($taggedServiceIds)) {
             return;
         }
 

--- a/src/DependencyInjection/Compiler/AddProvidersPass.php
+++ b/src/DependencyInjection/Compiler/AddProvidersPass.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Knp\Bundle\MenuBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
@@ -26,7 +27,7 @@ class AddProvidersPass implements CompilerPassInterface
             $providers[] = new Reference($id);
         }
 
-        if (1 === count($providers)) {
+        if (1 === \count($providers)) {
             // Use an alias instead of wrapping it in the ChainProvider for performances
             // when using only one (the default case as the bundle defines one provider)
             $container->setAlias('knp_menu.menu_provider', (string) reset($providers));

--- a/src/DependencyInjection/Compiler/AddRenderersPass.php
+++ b/src/DependencyInjection/Compiler/AddRenderersPass.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Knp\Bundle\MenuBundle\DependencyInjection\Compiler;
 
 use Knp\Menu\Renderer\PsrProvider;

--- a/src/DependencyInjection/Compiler/AddVotersPass.php
+++ b/src/DependencyInjection/Compiler/AddVotersPass.php
@@ -55,7 +55,7 @@ class AddVotersPass implements CompilerPassInterface
         }
 
         krsort($voters);
-        $sortedVoters = call_user_func_array('array_merge', $voters);
+        $sortedVoters = \call_user_func_array('array_merge', $voters);
 
         if (class_exists(IteratorArgument::class)) {
             $definition->replaceArgument(0, new IteratorArgument($sortedVoters));

--- a/src/DependencyInjection/Compiler/MenuPass.php
+++ b/src/DependencyInjection/Compiler/MenuPass.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Knp\Bundle\MenuBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -6,7 +6,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * This class contains the configuration information for the bundle
+ * This class contains the configuration information for the bundle.
  *
  * @author Christophe Coevoet <stof@notk.org>
  */

--- a/src/DependencyInjection/KnpMenuExtension.php
+++ b/src/DependencyInjection/KnpMenuExtension.php
@@ -62,7 +62,7 @@ class KnpMenuExtension extends Extension implements PrependExtensionInterface
      */
     public function getXsdValidationBasePath()
     {
-        return __DIR__ . '/../Resources/config/schema';
+        return __DIR__.'/../Resources/config/schema';
     }
 
     public function prepend(ContainerBuilder $container)
@@ -71,9 +71,8 @@ class KnpMenuExtension extends Extension implements PrependExtensionInterface
             return;
         }
 
-
         $refl = new \ReflectionClass(ItemInterface::class);
-        $path = dirname($refl->getFileName()).'/Resources/views';
+        $path = \dirname($refl->getFileName()).'/Resources/views';
 
         $container->prependExtensionConfig('twig', ['paths' => [$path]]);
     }

--- a/src/Provider/BuilderAliasProvider.php
+++ b/src/Provider/BuilderAliasProvider.php
@@ -10,7 +10,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
- * A menu provider that allows for an AcmeBundle:Builder:mainMenu shortcut syntax
+ * A menu provider that allows for an AcmeBundle:Builder:mainMenu shortcut syntax.
  *
  * @author Ryan Weaver <ryan@knplabs.com>
  */
@@ -32,7 +32,7 @@ class BuilderAliasProvider implements MenuProviderInterface
     }
 
     /**
-     * Looks for a menu with the bundle:class:method format
+     * Looks for a menu with the bundle:class:method format.
      *
      * For example, AcmeBundle:Builder:mainMenu would create and instantiate
      * an Acme\DemoBundle\Menu\Builder class and call the mainMenu() method
@@ -42,6 +42,7 @@ class BuilderAliasProvider implements MenuProviderInterface
      * @param array  $options
      *
      * @return \Knp\Menu\ItemInterface
+     *
      * @throws \InvalidArgumentException
      */
     public function get($name, array $options = [])
@@ -71,7 +72,7 @@ class BuilderAliasProvider implements MenuProviderInterface
      * @param string $name    The alias name of the menu
      * @param array  $options
      *
-     * @return Boolean
+     * @return bool
      */
     public function has($name, array $options = [])
     {
@@ -79,7 +80,7 @@ class BuilderAliasProvider implements MenuProviderInterface
     }
 
     /**
-     * Creates and returns the builder that lives in the given bundle
+     * Creates and returns the builder that lives in the given bundle.
      *
      * The convention is to look in the Menu namespace of the bundle for
      * this class, to instantiate it with no arguments, and to inject the
@@ -104,7 +105,7 @@ class BuilderAliasProvider implements MenuProviderInterface
             $allBundles = $this->kernel->getBundle($bundleName, false);
 
             // In Symfony 4, bundle inheritance is gone, so there is no way to get an array anymore.
-            if (!is_array($allBundles)) {
+            if (!\is_array($allBundles)) {
                 $allBundles = [$allBundles];
             }
 
@@ -120,7 +121,7 @@ class BuilderAliasProvider implements MenuProviderInterface
             }
 
             if (null === $class) {
-                if (1 === count($logs)) {
+                if (1 === \count($logs)) {
                     throw new \InvalidArgumentException($logs[0]);
                 }
 

--- a/src/Provider/BuilderServiceProvider.php
+++ b/src/Provider/BuilderServiceProvider.php
@@ -27,7 +27,7 @@ class BuilderServiceProvider implements MenuProviderInterface
             throw new \InvalidArgumentException(sprintf('The menu "%s" is not defined.', $name));
         }
 
-        if (!is_array($this->menuBuilders[$name]) || 2 !== count($this->menuBuilders[$name])) {
+        if (!\is_array($this->menuBuilders[$name]) || 2 !== \count($this->menuBuilders[$name])) {
             throw new \InvalidArgumentException(sprintf('The menu builder definition for the menu "%s" is invalid. It should be an array (serviceId, method)', $name));
         }
 

--- a/src/Renderer/ContainerAwareProvider.php
+++ b/src/Renderer/ContainerAwareProvider.php
@@ -21,7 +21,7 @@ class ContainerAwareProvider implements RendererProviderInterface
         $this->defaultRenderer = $defaultRenderer;
 
         if ($triggerDeprecation) {
-            @trigger_error(sprintf('The %s class is deprecated since 2.2 and will be removed in 3.0. USe "Knp\Menu\Renderer\PsrProvider" instead.', __CLASS__),E_USER_DEPRECATED);
+            @trigger_error(sprintf('The %s class is deprecated since 2.2 and will be removed in 3.0. USe "Knp\Menu\Renderer\PsrProvider" instead.', __CLASS__), E_USER_DEPRECATED);
         }
     }
 

--- a/src/Templating/Helper/MenuHelper.php
+++ b/src/Templating/Helper/MenuHelper.php
@@ -66,7 +66,7 @@ class MenuHelper extends TemplatingHelper
     }
 
     /**
-     * A string representation of this menu item
+     * A string representation of this menu item.
      *
      * e.g. Top Level 1 > Second Level > This menu
      *
@@ -85,7 +85,7 @@ class MenuHelper extends TemplatingHelper
      *
      * @param ItemInterface $item
      *
-     * @return boolean
+     * @return bool
      */
     public function isCurrent(ItemInterface $item)
     {
@@ -96,9 +96,9 @@ class MenuHelper extends TemplatingHelper
      * Checks whether an item is the ancestor of a current item.
      *
      * @param ItemInterface $item
-     * @param integer       $depth The max depth to look for the item
+     * @param int           $depth The max depth to look for the item
      *
-     * @return boolean
+     * @return bool
      */
     public function isAncestor(ItemInterface $item, $depth = null)
     {

--- a/tests/DependencyInjection/Compiler/AddExtensionsPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddExtensionsPassTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Knp\Bundle\MenuBundle\Tests\DependencyInjection\Compiler;
 
 use Knp\Bundle\MenuBundle\DependencyInjection\Compiler\AddExtensionsPass;
@@ -13,7 +14,7 @@ class AddExtensionsPassTest extends TestCase
         $containerBuilder = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->getMock();
         $containerBuilder->expects($this->once())
             ->method('has')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $containerBuilder->expects($this->never())
             ->method('findTaggedServiceIds');
 
@@ -31,7 +32,7 @@ class AddExtensionsPassTest extends TestCase
             ->getMock();
         $definitionMock->expects($this->at(0))
             ->method('getClass')
-            ->will($this->returnValue($menuFactoryClass));
+            ->willReturn($menuFactoryClass);
         $definitionMock->expects($this->at(1))
             ->method('addMethodCall')
             ->with($this->equalTo('addExtension'), $this->equalTo([new Reference('id'), 0]));
@@ -46,23 +47,23 @@ class AddExtensionsPassTest extends TestCase
         $parameterBagMock->expects($this->once())
             ->method('resolveValue')
             ->with($menuFactoryClass)
-            ->will($this->returnValue($menuFactoryClass));
+            ->willReturn($menuFactoryClass);
 
         $containerBuilderMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->getMock();
         $containerBuilderMock->expects($this->once())
             ->method('has')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $containerBuilderMock->expects($this->once())
             ->method('findTaggedServiceIds')
             ->with($this->equalTo('knp_menu.factory_extension'))
-            ->will($this->returnValue(['id' => ['tag1' => [], 'tag2' => ['priority' => 12]], 'foo' => ['tag1' => ['priority' => -4]]]));
+            ->willReturn(['id' => ['tag1' => [], 'tag2' => ['priority' => 12]], 'foo' => ['tag1' => ['priority' => -4]]]);
         $containerBuilderMock->expects($this->once())
             ->method('findDefinition')
             ->with($this->equalTo('knp_menu.factory'))
-            ->will($this->returnValue($definitionMock));
+            ->willReturn($definitionMock);
         $containerBuilderMock->expects($this->once())
             ->method('getParameterBag')
-            ->will($this->returnValue($parameterBagMock));
+            ->willReturn($parameterBagMock);
 
         $menuPass = new AddExtensionsPass();
         $menuPass->process($containerBuilderMock);
@@ -78,29 +79,29 @@ class AddExtensionsPassTest extends TestCase
             ->getMock();
         $definitionMock->expects($this->at(0))
             ->method('getClass')
-            ->will($this->returnValue('SimpleMenuFactory'));
+            ->willReturn('SimpleMenuFactory');
 
         $parameterBagMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface')->getMock();
         $parameterBagMock->expects($this->once())
             ->method('resolveValue')
             ->with('SimpleMenuFactory')
-            ->will($this->returnValue('SimpleMenuFactory'));
+            ->willReturn('SimpleMenuFactory');
 
         $containerBuilderMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->getMock();
         $containerBuilderMock->expects($this->once())
             ->method('has')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $containerBuilderMock->expects($this->once())
             ->method('findTaggedServiceIds')
             ->with($this->equalTo('knp_menu.factory_extension'))
-            ->will($this->returnValue(['id' => ['tag1' => [], 'tag2' => ['priority' => 12]], 'foo' => ['tag1' => ['priority' => -4]]]));
+            ->willReturn(['id' => ['tag1' => [], 'tag2' => ['priority' => 12]], 'foo' => ['tag1' => ['priority' => -4]]]);
         $containerBuilderMock->expects($this->once())
             ->method('findDefinition')
             ->with($this->equalTo('knp_menu.factory'))
-            ->will($this->returnValue($definitionMock));
+            ->willReturn($definitionMock);
         $containerBuilderMock->expects($this->once())
             ->method('getParameterBag')
-            ->will($this->returnValue($parameterBagMock));
+            ->willReturn($parameterBagMock);
 
         $menuPass = new AddExtensionsPass();
         $menuPass->process($containerBuilderMock);

--- a/tests/DependencyInjection/Compiler/AddProvidersPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddProvidersPassTest.php
@@ -14,7 +14,7 @@ class AddProvidersPassTest extends TestCase
         $containerBuilder = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->getMock();
         $containerBuilder->expects($this->once())
             ->method('hasDefinition')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $containerBuilder->expects($this->never())
             ->method('findTaggedServiceIds');
 
@@ -28,11 +28,11 @@ class AddProvidersPassTest extends TestCase
         $containerBuilderMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->getMock();
         $containerBuilderMock->expects($this->once())
             ->method('hasDefinition')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $containerBuilderMock->expects($this->once())
             ->method('findTaggedServiceIds')
             ->with($this->equalTo('knp_menu.provider'))
-            ->will($this->returnValue(['id' => ['provider_tag1']]));
+            ->willReturn(['id' => ['provider_tag1']]);
         $containerBuilderMock->expects($this->once())
             ->method('setAlias')
             ->with(
@@ -62,14 +62,14 @@ class AddProvidersPassTest extends TestCase
         $containerBuilderMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->getMock();
         $containerBuilderMock->expects($this->once())
             ->method('hasDefinition')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $containerBuilderMock->expects($this->once())
             ->method('findTaggedServiceIds')
             ->with($this->equalTo('knp_menu.provider'))
-            ->will($this->returnValue([
+            ->willReturn([
                 'id' => ['provider_tag1'],
-                'id2' => ['provider_tag2']
-            ]));
+                'id2' => ['provider_tag2'],
+            ]);
         $containerBuilderMock->expects($this->once())
             ->method('setAlias')
             ->with(
@@ -79,7 +79,7 @@ class AddProvidersPassTest extends TestCase
         $containerBuilderMock->expects($this->once())
             ->method('getDefinition')
             ->with($this->equalTo('knp_menu.menu_provider.chain'))
-            ->will($this->returnValue($definitionMock));
+            ->willReturn($definitionMock);
 
         $providersPass = new AddProvidersPass();
         $providersPass->process($containerBuilderMock);

--- a/tests/DependencyInjection/Compiler/AddRenderersPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddRenderersPassTest.php
@@ -19,7 +19,7 @@ class AddRenderersPassTest extends TestCase
         $containerBuilder = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->getMock();
         $containerBuilder->expects($this->once())
             ->method('hasDefinition')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $containerBuilder->expects($this->never())
             ->method('findTaggedServiceIds');
 
@@ -36,11 +36,11 @@ class AddRenderersPassTest extends TestCase
         $containerBuilderMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->getMock();
         $containerBuilderMock->expects($this->once())
             ->method('hasDefinition')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $containerBuilderMock->expects($this->once())
             ->method('findTaggedServiceIds')
             ->with($this->equalTo('knp_menu.renderer'))
-            ->will($this->returnValue(['id' => ['tag1' => ['alias' => '']]]));
+            ->willReturn(['id' => ['tag1' => ['alias' => '']]]);
 
         $renderersPass = new AddRenderersPass();
         $renderersPass->process($containerBuilderMock);

--- a/tests/DependencyInjection/Compiler/AddVotersPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddVotersPassTest.php
@@ -14,7 +14,7 @@ class AddVotersPassTest extends TestCase
         $containerBuilder = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->getMock();
         $containerBuilder->expects($this->once())
             ->method('hasDefinition')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $containerBuilder->expects($this->never())
             ->method('findTaggedServiceIds');
 
@@ -46,19 +46,19 @@ class AddVotersPassTest extends TestCase
         $containerBuilderMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->getMock();
         $containerBuilderMock->expects($this->once())
             ->method('hasDefinition')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $containerBuilderMock->expects($this->once())
             ->method('findTaggedServiceIds')
             ->with($this->equalTo('knp_menu.voter'))
-            ->will($this->returnValue(['id' => [[]], 'bar' => [['priority' => -5, 'request' => false]], 'foo' => [[]]]));
+            ->willReturn(['id' => [[]], 'bar' => [['priority' => -5, 'request' => false]], 'foo' => [[]]]);
         $containerBuilderMock->expects($this->at(1))
             ->method('getDefinition')
             ->with($this->equalTo('knp_menu.matcher'))
-            ->will($this->returnValue($definitionMock));
+            ->willReturn($definitionMock);
         $containerBuilderMock->expects($this->at(2))
             ->method('getDefinition')
             ->with($this->equalTo('knp_menu.listener.voters'))
-            ->will($this->returnValue($listenerMock));
+            ->willReturn($listenerMock);
         $containerBuilderMock->expects($this->once())
             ->method('removeDefinition')
             ->with('knp_menu.listener.voters');
@@ -96,19 +96,19 @@ class AddVotersPassTest extends TestCase
         $containerBuilderMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->getMock();
         $containerBuilderMock->expects($this->once())
             ->method('hasDefinition')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $containerBuilderMock->expects($this->once())
             ->method('findTaggedServiceIds')
             ->with($this->equalTo('knp_menu.voter'))
-            ->will($this->returnValue(['id' => [[]], 'bar' => [['priority' => -5, 'request' => false]], 'foo' => [['request' => true]]]));
+            ->willReturn(['id' => [[]], 'bar' => [['priority' => -5, 'request' => false]], 'foo' => [['request' => true]]]);
         $containerBuilderMock->expects($this->at(1))
             ->method('getDefinition')
             ->with($this->equalTo('knp_menu.matcher'))
-            ->will($this->returnValue($definitionMock));
+            ->willReturn($definitionMock);
         $containerBuilderMock->expects($this->at(2))
             ->method('getDefinition')
             ->with($this->equalTo('knp_menu.listener.voters'))
-            ->will($this->returnValue($listenerMock));
+            ->willReturn($listenerMock);
 
         $menuPass = new AddVotersPass();
         $menuPass->process($containerBuilderMock);

--- a/tests/DependencyInjection/Compiler/MenuPassTest.php
+++ b/tests/DependencyInjection/Compiler/MenuPassTest.php
@@ -12,7 +12,7 @@ class MenuPassTest extends TestCase
         $containerBuilder = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->getMock();
         $containerBuilder->expects($this->once())
             ->method('hasDefinition')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $containerBuilder->expects($this->never())
             ->method('findTaggedServiceIds');
 
@@ -29,11 +29,11 @@ class MenuPassTest extends TestCase
         $containerBuilderMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->getMock();
         $containerBuilderMock->expects($this->once())
             ->method('hasDefinition')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $containerBuilderMock->expects($this->once())
             ->method('findTaggedServiceIds')
             ->with($this->equalTo('knp_menu.menu'))
-            ->will($this->returnValue(['id' => ['tag1' => ['alias' => '']]]));
+            ->willReturn(['id' => ['tag1' => ['alias' => '']]]);
 
         $menuPass = new MenuPass();
         $menuPass->process($containerBuilderMock);
@@ -51,15 +51,15 @@ class MenuPassTest extends TestCase
         $containerBuilderMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->getMock();
         $containerBuilderMock->expects($this->once())
             ->method('hasDefinition')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $containerBuilderMock->expects($this->once())
             ->method('findTaggedServiceIds')
             ->with($this->equalTo('knp_menu.menu'))
-            ->will($this->returnValue(['id' => ['tag1' => ['alias' => 'test_alias']]]));
+            ->willReturn(['id' => ['tag1' => ['alias' => 'test_alias']]]);
         $containerBuilderMock->expects($this->once())
             ->method('getDefinition')
             ->with($this->equalTo('knp_menu.menu_provider.container_aware'))
-            ->will($this->returnValue($definitionMock));
+            ->willReturn($definitionMock);
 
         $menuPass = new MenuPass();
         $menuPass->process($containerBuilderMock);

--- a/tests/DependencyInjection/Compiler/RegisterMenusPassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterMenusPassTest.php
@@ -117,6 +117,5 @@ class RegisterMenusPassTest extends TestCase
         $this->definition->replaceArgument(0, $menus)->shouldBeCalled();
 
         $this->pass->process($this->containerBuilder->reveal());
-
     }
 }

--- a/tests/EventListener/VoterInitializerListenerTest.php
+++ b/tests/EventListener/VoterInitializerListenerTest.php
@@ -19,7 +19,7 @@ class VoterInitializerListenerTest extends TestCase
             ->getMock();
         $event->expects($this->once())
             ->method('getRequestType')
-            ->will($this->returnValue(HttpKernelInterface::SUB_REQUEST));
+            ->willReturn(HttpKernelInterface::SUB_REQUEST);
 
         $voter = $this->getMockBuilder('Knp\Menu\Matcher\Voter\RouteVoter')
             ->disableOriginalConstructor()
@@ -42,10 +42,10 @@ class VoterInitializerListenerTest extends TestCase
             ->getMock();
         $event->expects($this->once())
             ->method('getRequestType')
-            ->will($this->returnValue(HttpKernelInterface::MASTER_REQUEST));
+            ->willReturn(HttpKernelInterface::MASTER_REQUEST);
         $event->expects($this->once())
             ->method('getRequest')
-            ->will($this->returnValue($request));
+            ->willReturn($request);
 
         $voter = $this->getMockBuilder('Knp\Menu\Matcher\Voter\RouteVoter')
             ->disableOriginalConstructor()

--- a/tests/Provider/BuilderAliasProviderTest.php
+++ b/tests/Provider/BuilderAliasProviderTest.php
@@ -29,7 +29,7 @@ class BuilderAliasProviderTest extends TestCase
         $factory->expects($this->once())
             ->method('createItem')
             ->with('Main menu')
-            ->will($this->returnValue($item));
+            ->willReturn($item);
 
         $provider = new BuilderAliasProvider(
             $this->createMockKernelForStub(),
@@ -50,7 +50,7 @@ class BuilderAliasProviderTest extends TestCase
         $factory->expects($this->once())
             ->method('createItem')
             ->with('Main menu')
-            ->will($this->returnValue($item));
+            ->willReturn($item);
 
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $container->expects($this->once())
@@ -140,7 +140,7 @@ class BuilderAliasProviderTest extends TestCase
         $factory->expects($this->once())
             ->method('createItem')
             ->with('Main menu')
-            ->will($this->returnValue($item));
+            ->willReturn($item);
 
         $provider = new BuilderAliasProvider(
             $this->createTestKernel(),
@@ -168,7 +168,7 @@ class BuilderAliasProviderTest extends TestCase
         $factory->expects($this->once())
             ->method('createItem')
             ->with('Main menu for the child')
-            ->will($this->returnValue($item));
+            ->willReturn($item);
 
         $provider = new BuilderAliasProvider(
             $this->createTestKernel('Knp\Bundle\MenuBundle\Tests\Stubs\Child'),
@@ -210,18 +210,18 @@ class BuilderAliasProviderTest extends TestCase
         $bundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\BundleInterface')->getMock();
         $bundle->expects($this->once())
             ->method('getNamespace')
-            ->will($this->returnValue('Knp\Bundle\MenuBundle\Tests\Stubs'))
+            ->willReturn('Knp\Bundle\MenuBundle\Tests\Stubs')
         ;
         $bundle->expects($this->any())
             ->method('getName')
-            ->will($this->returnValue('FooBundle'))
+            ->willReturn('FooBundle')
         ;
 
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
         $kernel->expects($this->once())
             ->method('getBundle')
             ->with('FooBundle', false)
-            ->will($this->returnValue([$bundle]))
+            ->willReturn([$bundle])
         ;
 
         return $kernel;
@@ -232,25 +232,25 @@ class BuilderAliasProviderTest extends TestCase
         $bundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\BundleInterface')->getMock();
         $bundle->expects($this->any())
             ->method('getNamespace')
-            ->will($this->returnValue($parentNamespace))
+            ->willReturn($parentNamespace)
         ;
         $bundle->expects($this->any())
             ->method('getName')
-            ->will($this->returnValue('FooBundle'))
+            ->willReturn('FooBundle')
         ;
 
         $childBundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\BundleInterface')->getMock();
         $childBundle->expects($this->any())
             ->method('getNamespace')
-            ->will($this->returnValue($childNamespace))
+            ->willReturn($childNamespace)
         ;
         $childBundle->expects($this->any())
             ->method('getName')
-            ->will($this->returnValue('BarBundle'))
+            ->willReturn('BarBundle')
         ;
         $childBundle->expects($this->any())
             ->method('getParent')
-            ->will($this->returnValue('FooBundle'))
+            ->willReturn('FooBundle')
         ;
 
         $kernel = new TestKernel([$bundle, $childBundle]);

--- a/tests/Provider/ContainerAwareProviderTest.php
+++ b/tests/Provider/ContainerAwareProviderTest.php
@@ -22,7 +22,7 @@ class ContainerAwareProviderTest extends TestCase
         $container->expects($this->once())
             ->method('get')
             ->with('menu')
-            ->will($this->returnValue($menu))
+            ->willReturn($menu)
         ;
         $provider = new ContainerAwareProvider($container, ['default' => 'menu']);
         $this->assertSame($menu, $provider->get('default'));

--- a/tests/Renderer/ContainerAwareProviderTest.php
+++ b/tests/Renderer/ContainerAwareProviderTest.php
@@ -29,7 +29,7 @@ class ContainerAwareProviderTest extends TestCase
         $container->expects($this->once())
             ->method('get')
             ->with('renderer')
-            ->will($this->returnValue($renderer))
+            ->willReturn($renderer)
         ;
         $provider = new ContainerAwareProvider($container, 'custom', ['default' => 'renderer', 'custom' => 'other']);
         $this->assertSame($renderer, $provider->get('default'));
@@ -42,7 +42,7 @@ class ContainerAwareProviderTest extends TestCase
         $container->expects($this->once())
             ->method('get')
             ->with('renderer')
-            ->will($this->returnValue($renderer))
+            ->willReturn($renderer)
         ;
         $provider = new ContainerAwareProvider($container, 'default', ['default' => 'renderer']);
         $this->assertSame($renderer, $provider->get());

--- a/tests/Templating/MenuHelperTest.php
+++ b/tests/Templating/MenuHelperTest.php
@@ -6,7 +6,7 @@ use Knp\Bundle\MenuBundle\Templating\Helper\MenuHelper;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Test for MenuHelper class
+ * Test for MenuHelper class.
  *
  * @author Leszek Prabucki <leszek.prabucki@gmail.com>
  */
@@ -18,7 +18,7 @@ class MenuHelperTest extends TestCase
         $helperMock->expects($this->any())
             ->method('get')
             ->with($this->equalTo('test'), $this->equalTo(['pathArray']))
-            ->will($this->returnValue('returned value'));
+            ->willReturn('returned value');
 
         $helper = new MenuHelper($helperMock, $this->getMatcherMock(), $this->getManipulatorMock());
 
@@ -33,7 +33,7 @@ class MenuHelperTest extends TestCase
         $helperMock->expects($this->any())
             ->method('get')
             ->with('default', [], ['foo' => 'bar'])
-            ->will($this->returnValue($menu))
+            ->willReturn($menu)
         ;
 
         $helper = new MenuHelper($helperMock, $this->getMatcherMock(), $this->getManipulatorMock());
@@ -47,7 +47,7 @@ class MenuHelperTest extends TestCase
         $helperMock->expects($this->any())
             ->method('render')
             ->with($this->equalTo('test'), $this->equalTo(['options']))
-            ->will($this->returnValue('returned value'));
+            ->willReturn('returned value');
 
         $helper = new MenuHelper($helperMock, $this->getMatcherMock(), $this->getManipulatorMock());
 
@@ -67,7 +67,7 @@ class MenuHelperTest extends TestCase
         $helperMock->expects($this->any())
             ->method('getBreadcrumbsArray')
             ->with('default')
-            ->will($this->returnValue(['A', 'B']))
+            ->willReturn(['A', 'B'])
         ;
 
         $helper = new MenuHelper($helperMock, $this->getMatcherMock(), $this->getManipulatorMock());
@@ -83,7 +83,7 @@ class MenuHelperTest extends TestCase
         $manipulatorMock->expects($this->any())
             ->method('getPathAsString')
             ->with($menu)
-            ->will($this->returnValue('A > B'))
+            ->willReturn('A > B')
         ;
 
         $helper = new MenuHelper($this->getHelperMock(), $this->getMatcherMock(), $manipulatorMock);
@@ -117,7 +117,7 @@ class MenuHelperTest extends TestCase
         $matcherMock->expects($this->any())
             ->method('isAncestor')
             ->with($menu)
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
 
         $helper = new MenuHelper($this->getHelperMock(), $matcherMock, $this->getManipulatorMock());
@@ -133,7 +133,7 @@ class MenuHelperTest extends TestCase
         $helperMock->expects($this->any())
             ->method('getCurrentItem')
             ->with('default')
-            ->will($this->returnValue($menu))
+            ->willReturn($menu)
         ;
 
         $helper = new MenuHelper($helperMock, $this->getMatcherMock(), $this->getManipulatorMock());


### PR DESCRIPTION
Being this a Symfony bundle, I think that [Symfony coding standards](https://symfony.com/doc/current/contributing/code/standards.html) should be enforced.
This PR adds a configuration file for php-cs-fixer (and fixes all files)