### PR TITLE
Bumped symfony 4 minor version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
     "require": {
         "php": "^7.2",
         "knplabs/knp-menu": "^3.0",
-        "symfony/framework-bundle": "^3.4 | ^4.0 | ^5.0"
+        "symfony/framework-bundle": "^3.4 | ^4.2 | ^5.0"
     },
     "require-dev": {
         "phpspec/prophecy": "^1.8",
-        "symfony/phpunit-bridge": "^3.4 | ^4.0 | ^5.0",
-        "symfony/expression-language": "^3.4 | ^4.0 | ^5.0",
+        "symfony/phpunit-bridge": "^3.4 | ^4.2 | ^5.0",
+        "symfony/expression-language": "^3.4 | ^4.2 | ^5.0",
         "symfony/templating": "^3.4 | ^4.0 | ^5.0"
     },
     "autoload": {


### PR DESCRIPTION
As 4.0 is no longer maintained I suggest to bump the version to 4.2 (the first minor of 4.x main that still receives updates).