### PR TITLE
Fix travis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/framework-bundle": "^3.4 | ^4.2 | ^5.0"
     },
     "require-dev": {
-        "phpspec/prophecy": "^1.8",
+        "phpspec/prophecy": "^1.9",
         "symfony/phpunit-bridge": "^3.4 | ^4.2 | ^5.0",
         "symfony/expression-language": "^3.4 | ^4.2 | ^5.0",
         "symfony/templating": "^3.4 | ^4.0 | ^5.0"


### PR DESCRIPTION
In order to fix this PR: https://github.com/KnpLabs/KnpMenuBundle/pull/424 I updated phpspec/prophecy to ^1.9 that introduce a fix for the following error:

PHP Fatal error:  Declaration of Prophecy\Comparator\ProphecyComparator::assertEquals($expected, $actual, $delta = 0, $canonicalize = false, $ignoreCase = false, array &$processed = Array) must be compatible with SebastianBergmann\Comparator\ObjectComparator::assertEquals($expected, $actual, $delta = 0, $canonicalize = false, $ignoreCase = false, array &$processed = Array): void in /home/travis/build/KnpLabs/KnpMenuBundle/vendor/phpspec/prophecy/src/Prophecy/Comparator/ProphecyComparator.php on line 24

See: https://github.com/phpspec/prophecy/issues/451