### PR TITLE
Switch the parameter order for the event example

### DIFF
--- a/docs/events.rst
+++ b/docs/events.rst
@@ -33,8 +33,8 @@ to allow other parts of your application to add more stuff to it.
           $menu->addChild('Dashboard', ['route' => '_acp_dashboard']);
 
           $this->container->get('event_dispatcher')->dispatch(
-              ConfigureMenuEvent::CONFIGURE,
-              new ConfigureMenuEvent($factory, $menu)
+              new ConfigureMenuEvent($factory, $menu),
+              ConfigureMenuEvent::CONFIGURE
           );
 
           return $menu;


### PR DESCRIPTION
Dispatch now takes the event first, and event name second.