### PR TITLE
Add configuration for symfony.com's bundle section

### DIFF
--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -1,0 +1,6 @@
+branch: ["master"]
+maintained_branches: ["master"]
+current_branch: "master"
+dev_branch: "master"
+dev_branch_alias: "3.x"
+doc_dir: "docs/"


### PR DESCRIPTION
Symfony.com recently launched a new bundle section: https://symfony.com/bundles

This bundle needs to add some configuration in order to be visible on this website. This used to be configured in an internal repository, but the bundle is now able to change the doc versioning in their own repository.

cc @garak 