### PR TITLE
Refactor tests to not rely on external mock classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "symfony/framework-bundle": "^3.4 | ^4.4 | ^5.0"
     },
     "require-dev": {
-        "phpspec/prophecy": "^1.8",
         "phpunit/phpunit": "^8.5 | ^9.5",
         "symfony/expression-language": "^3.4 | ^4.4 | ^5.0",
         "symfony/phpunit-bridge": "^5.2",


### PR DESCRIPTION
The behavior of tests is the same but now we don't mock what we don't own.
Also it solves the problem with prophecy and php 8 static return type.

wdyt @stof @garak 