### PR TITLE
Fix return value for getBundle function in tests

### DIFF
--- a/tests/Provider/BuilderAliasProviderTest.php
+++ b/tests/Provider/BuilderAliasProviderTest.php
@@ -213,7 +213,7 @@ class BuilderAliasProviderTest extends TestCase
         $kernel->expects($this->once())
             ->method('getBundle')
             ->with('FooBundle', false)
-            ->willReturn([$bundle])
+            ->willReturn($bundle)
         ;
 
         return $kernel;


### PR DESCRIPTION
To fix #446 