### PR TITLE
feat: bump minimum php version to 7.4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,9 +48,6 @@ jobs:
                     - description: 'Symfony 5.4'
                       php: '8.0'
                       symfony: 5.4.*
-                    - description: 'Symfony 6.0'
-                      php: '8.0'
-                      symfony: 6.0.*
                     - description: 'Dev deps'
                       php: '8.1'
                       dev: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,15 +29,13 @@ jobs:
             matrix:
                 include:
                     - description: 'No Symfony specified'
-                      php: '7.2'
-                    - description: 'No Symfony specified'
-                      php: '7.3'
-                    - description: 'No Symfony specified'
                       php: '7.4'
                     - description: 'No Symfony specified'
                       php: '8.0'
+                    - description: 'No Symfony specified'
+                      php: '8.1'
                     - description: 'Lowest deps'
-                      php: '7.2'
+                      php: '7.4'
                       composer_option: '--prefer-lowest'
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: max[self]=0
@@ -47,8 +45,14 @@ jobs:
                     - description: 'Symfony 4.4'
                       php: '7.4'
                       symfony: 4.4.*
-                    - description: 'Dev deps'
+                    - description: 'Symfony 5.4'
                       php: '8.0'
+                      symfony: 5.4.*
+                    - description: 'Symfony 6.0'
+                      php: '8.0'
+                      symfony: 6.0.*
+                    - description: 'Dev deps'
+                      php: '8.1'
                       dev: true
         name: PHP ${{ matrix.php }} tests (${{ matrix.description }})
         steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.0 (2022-xx-xx)
+
+* Increased minimum PHP version to 7.4 (to be consistent with KnpMenu 3.4)
+
 ## 3.1.0 (2020-11-29)
 
 * Add support for php 8

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
-        "knplabs/knp-menu": "^3.1",
+        "php": "^7.4 || ^8.0",
+        "knplabs/knp-menu": "^3.3",
         "symfony/framework-bundle": "^3.4 | ^4.4 | ^5.0 | ^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5 | ^9.5",
+        "phpunit/phpunit": "^9.5",
         "symfony/expression-language": "^3.4 | ^4.4 | ^5.0 | ^6.0",
-        "symfony/phpunit-bridge": "^5.2 | ^6.0",
+        "symfony/phpunit-bridge": "^6.0",
         "symfony/templating": "^3.4 | ^4.4 | ^5.0 | ^6.0"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit colors="true" bootstrap="vendor/autoload.php">
-    <testsuites>
-        <testsuite name="KnpMenuBundle Test Suite">
-            <directory suffix="Test.php">./tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./src</directory>
-            <exclude>
-                <directory>./src/Resources</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>./src</directory>
+    </include>
+    <exclude>
+      <directory>./src/Resources</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="KnpMenuBundle Test Suite">
+      <directory suffix="Test.php">./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          colors="true"
          bootstrap="vendor/autoload.php"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd">
   <coverage>
     <include>
       <directory>./src</directory>

--- a/src/DependencyInjection/Compiler/AddExtensionsPass.php
+++ b/src/DependencyInjection/Compiler/AddExtensionsPass.php
@@ -37,7 +37,7 @@ final class AddExtensionsPass implements CompilerPassInterface
 
         foreach ($taggedServiceIds as $id => $tags) {
             foreach ($tags as $tag) {
-                $priority = isset($tag['priority']) ? $tag['priority'] : 0;
+                $priority = $tag['priority'] ?? 0;
                 $definition->addMethodCall('addExtension', [new Reference($id), $priority]);
             }
         }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -14,10 +14,8 @@ class Configuration implements ConfigurationInterface
 {
     /**
      * Generates the configuration tree.
-     *
-     * @return TreeBuilder
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('knp_menu');
 

--- a/src/Provider/BuilderAliasProvider.php
+++ b/src/Provider/BuilderAliasProvider.php
@@ -16,13 +16,13 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 final class BuilderAliasProvider implements MenuProviderInterface
 {
-    private $kernel;
+    private KernelInterface $kernel;
 
-    private $container;
+    private ContainerInterface $container;
 
-    private $menuFactory;
+    private FactoryInterface $menuFactory;
 
-    private $builders = [];
+    private array $builders = [];
 
     public function __construct(KernelInterface $kernel, ContainerInterface $container, FactoryInterface $menuFactory)
     {

--- a/tests/DependencyInjection/Compiler/MenuBuilderPassTest.php
+++ b/tests/DependencyInjection/Compiler/MenuBuilderPassTest.php
@@ -8,15 +8,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class MenuBuilderPassTest extends TestCase
 {
-    /**
-     * @var ContainerBuilder
-     */
-    private $containerBuilder;
+    private ContainerBuilder $containerBuilder;
 
-    /**
-     * @var MenuBuilderPass
-     */
-    private $pass;
+    private MenuBuilderPass $pass;
 
     protected function setUp(): void
     {

--- a/tests/DependencyInjection/Compiler/RegisterMenusPassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterMenusPassTest.php
@@ -12,15 +12,9 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class RegisterMenusPassTest extends TestCase
 {
-    /**
-     * @var ContainerBuilder
-     */
-    private $containerBuilder;
+    private ContainerBuilder $containerBuilder;
 
-    /**
-     * @var RegisterMenusPass
-     */
-    private $pass;
+    private RegisterMenusPass $pass;
 
     protected function setUp(): void
     {

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -26,7 +26,7 @@ class ConfigurationTest extends TestCase
         $this->assertTrue($configIsValid, \implode(\PHP_EOL, $errors));
     }
 
-    public function getConfigs()
+    public function getConfigs(): array
     {
         return [
             ['<config xmlns="http://knplabs.com/schema/dic/menu"/>'],

--- a/tests/Provider/BuilderAliasProviderTest.php
+++ b/tests/Provider/BuilderAliasProviderTest.php
@@ -219,7 +219,7 @@ class BuilderAliasProviderTest extends TestCase
         return $kernel;
     }
 
-    private function createTestKernel($childNamespace = 'Bar', $parentNamespace = 'Knp\Bundle\MenuBundle\Tests\Stubs')
+    private function createTestKernel($childNamespace = 'Bar', $parentNamespace = 'Knp\Bundle\MenuBundle\Tests\Stubs'): TestKernel
     {
         $bundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\BundleInterface')->getMock();
         $bundle->expects($this->any())

--- a/tests/Stubs/Child/Menu/Builder.php
+++ b/tests/Stubs/Child/Menu/Builder.php
@@ -3,10 +3,11 @@
 namespace Knp\Bundle\MenuBundle\Tests\Stubs\Child\Menu;
 
 use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
 
 class Builder
 {
-    public function mainMenu(FactoryInterface $factory)
+    public function mainMenu(FactoryInterface $factory): ItemInterface
     {
         return $factory->createItem('Main menu for the child');
     }

--- a/tests/Stubs/Menu/Builder.php
+++ b/tests/Stubs/Menu/Builder.php
@@ -3,15 +3,16 @@
 namespace Knp\Bundle\MenuBundle\Tests\Stubs\Menu;
 
 use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
 
 class Builder
 {
-    public function mainMenu(FactoryInterface $factory)
+    public function mainMenu(FactoryInterface $factory): ItemInterface
     {
         return $factory->createItem('Main menu');
     }
 
-    public function invalidMethod(FactoryInterface $factory)
+    public function invalidMethod(FactoryInterface $factory): \stdClass
     {
         return new \stdClass();
     }

--- a/tests/Stubs/Menu/ContainerAwareBuilder.php
+++ b/tests/Stubs/Menu/ContainerAwareBuilder.php
@@ -3,19 +3,20 @@
 namespace Knp\Bundle\MenuBundle\Tests\Stubs\Menu;
 
 use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class ContainerAwareBuilder implements ContainerAwareInterface
 {
-    private $container;
+    private ContainerInterface $container;
 
     public function setContainer(ContainerInterface $container = null): void
     {
         $this->container = $container;
     }
 
-    public function mainMenu(FactoryInterface $factory)
+    public function mainMenu(FactoryInterface $factory): ItemInterface
     {
         // Check that the container is really set.
         $this->container->get('test');

--- a/tests/Stubs/TestKernel.php
+++ b/tests/Stubs/TestKernel.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class TestKernel extends Kernel
 {
-    private $mockBundles;
+    private array $mockBundles;
 
     public function __construct(array $bundles)
     {
@@ -16,7 +16,7 @@ class TestKernel extends Kernel
         parent::__construct('test', false);
     }
 
-    public function registerBundles()
+    public function registerBundles(): array
     {
         return $this->mockBundles;
     }

--- a/tests/Stubs/TestKernel.php
+++ b/tests/Stubs/TestKernel.php
@@ -16,7 +16,7 @@ class TestKernel extends Kernel
         parent::__construct('test', false);
     }
 
-    public function registerBundles(): array
+    public function registerBundles(): iterable
     {
         return $this->mockBundles;
     }


### PR DESCRIPTION
A first step for PHP >= 7.4
see https://github.com/KnpLabs/KnpMenuBundle/issues/449

Of course should be wait until this PR is released. https://github.com/KnpLabs/KnpMenu/pull/365 

I am not sure about changes in GitHub Actions.
https://github.com/KnpLabs/KnpMenuBundle/blob/master/src/Templating/Helper/MenuHelper.php is spared from changes to avoid BC breaks. Is this correct or can i change that file?
