### PR TITLE
Update Symfony bundle config

### DIFF
--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -1,4 +1,4 @@
-branch: ["master"]
+branches: ["master"]
 maintained_branches: ["master"]
 current_branch: "master"
 dev_branch: "master"


### PR DESCRIPTION
This option must be called `branches` in plural even if it only includes one. Found while building docs for this bundle:

```
// repos/KnpLabs/KnpMenuBundle/contents/.symfony.bundle.yaml config has the following validation errors.
branches: This value should not be blank.
```
