### PR TITLE
Update URL to symfony flex documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -327,5 +327,5 @@ More Advanced Stuff
     disabling_providers
 
 .. _`installation chapter`: https://getcomposer.org/doc/00-intro.md
-.. _`Flex`: https://flex.symfony.com
+.. _`Flex`: https://symfony.com/doc/current/setup/flex.html
 .. _`KnpMenu documentation`: https://github.com/KnpLabs/KnpMenu/blob/master/doc/01-Basic-Menus.md


### PR DESCRIPTION
The link : https://flex.symfony.com/ is not working. Proposing to change the url.