### PR TITLE
feat: drop support for php 8.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,18 +29,16 @@ jobs:
             matrix:
                 include:
                     - description: 'No Symfony specified'
-                      php: '8.0'
-                    - description: 'No Symfony specified'
                       php: '8.1'
                     - description: 'No Symfony specified'
                       php: '8.2'
                     - description: 'No Symfony specified'
                       php: '8.3'
                     - description: 'Lowest deps'
-                      php: '8.0'
+                      php: '8.1'
                       composer_option: '--prefer-lowest'
                     - description: 'Symfony 5.4'
-                      php: '8.0'
+                      php: '8.1'
                       symfony: 5.4.*
                     - description: 'Symfony 7'
                       php: '8.2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 3.3.0 (2023-05-xx)
+## 3.4.0 (2024-xx-xx)
+
+* Increased minimum PHP version to 8.1 (to be consistent with KnpMenu 3.5)
+
+## 3.3.0 (2023-10-23)
 
 * Increased minimum PHP version to 8.0 (to be consistent with KnpMenu 3.4)
 * Dropped support for Symfony 3 and 4

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "knplabs/knp-menu": "^3.3",
         "symfony/deprecation-contracts": "^2.5 | ^3.3",
         "symfony/framework-bundle": "^5.4 | ^6.0 | ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6 | ^10.1",
+        "phpunit/phpunit": "^10.5 | ^11.0.3",
         "symfony/expression-language": "^5.4 | ^6.0 | ^7.0",
         "symfony/phpunit-bridge": "^6.0 | ^7.0",
         "symfony/templating": "^5.4 | ^6.0 | ^7.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,18 +2,21 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          colors="true"
          bootstrap="vendor/autoload.php"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd">
-  <coverage>
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd">
+
+  <testsuites>
+    <testsuite name="KnpMenuBundle Test Suite">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
+
+  <source>
     <include>
       <directory>./src</directory>
     </include>
     <exclude>
       <directory>./src/Resources</directory>
     </exclude>
-  </coverage>
-  <testsuites>
-    <testsuite name="KnpMenuBundle Test Suite">
-      <directory suffix="Test.php">./tests/</directory>
-    </testsuite>
-  </testsuites>
+  </source>
+
 </phpunit>

--- a/tests/DependencyInjection/Compiler/AddVotersPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddVotersPassTest.php
@@ -4,6 +4,7 @@ namespace Knp\Bundle\MenuBundle\Tests\DependencyInjection\Compiler;
 
 use Knp\Bundle\MenuBundle\DependencyInjection\Compiler\AddVotersPass;
 use Knp\Menu\Matcher\Matcher;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -41,9 +42,7 @@ class AddVotersPassTest extends TestCase
         );
     }
 
-    /**
-     * @group legacy
-     */
+    #[Group('legacy')]
     public function testProcessRequestAware(): void
     {
         $containerBuilder = new ContainerBuilder();

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -2,13 +2,12 @@
 
 namespace Knp\Bundle\MenuBundle\Tests\DependencyInjection;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class ConfigurationTest extends TestCase
 {
-    /**
-     * @dataProvider getConfigs
-     */
+    #[DataProvider('getConfigs')]
     public function testConfigurationMatchesXsd($config): void
     {
         $configDom = new \DOMDocument();

--- a/tests/DependencyInjection/KnpMenuExtensionTest.php
+++ b/tests/DependencyInjection/KnpMenuExtensionTest.php
@@ -3,6 +3,7 @@
 namespace Knp\Bundle\MenuBundle\Tests\DependencyInjection;
 
 use Knp\Bundle\MenuBundle\DependencyInjection\KnpMenuExtension;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -47,9 +48,7 @@ class KnpMenuExtensionTest extends TestCase
         $this->assertFalse($container->hasDefinition('knp_menu.renderer.twig'));
     }
 
-    /**
-     * @group legacy
-     */
+    #[Group('legacy')]
     public function testEnablePhpTemplates(): void
     {
         $container = new ContainerBuilder();

--- a/tests/Templating/MenuHelperTest.php
+++ b/tests/Templating/MenuHelperTest.php
@@ -4,14 +4,15 @@ namespace Knp\Bundle\MenuBundle\Tests\Templating;
 
 use Knp\Bundle\MenuBundle\Templating\Helper\MenuHelper;
 use Knp\Menu\ItemInterface;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test for MenuHelper class.
  *
  * @author Leszek Prabucki <leszek.prabucki@gmail.com>
- * @group legacy
  */
+#[Group('legacy')]
 class MenuHelperTest extends TestCase
 {
     public function testGet(): void


### PR DESCRIPTION
migrate phpunit.xml.dist to version 10
allow PHPUnit 11

The change to Attributes, is to fix the deprecation warnings from PHPUnit 11

Maybe it is already time to drop support for php 8.0
https://github.com/KnpLabs/KnpMenuBundle/pull/460#issuecomment-1761147457