### PR TITLE
Fix the bundle path to support the new bundle structure

### DIFF
--- a/src/KnpMenuBundle.php
+++ b/src/KnpMenuBundle.php
@@ -24,4 +24,9 @@ final class KnpMenuBundle extends Bundle
         $container->addCompilerPass(new AddRenderersPass());
         $container->addCompilerPass(new AddVotersPass());
     }
+
+    public function getPath(): string
+    {
+        return \dirname(__DIR__);
+    }
 }


### PR DESCRIPTION
Without the proper definition of the bundle path, the templates are not discovered by TwigBundle when placed in the new location.

Closes #476