### PR TITLE
Add registration of the CallbackVoter

### DIFF
--- a/config/menu.xml
+++ b/config/menu.xml
@@ -59,6 +59,10 @@
             <argument>%kernel.charset%</argument>
         </service>
 
+        <service id="knp_menu.voter.callback" class="Knp\Menu\Matcher\Voter\CallbackVoter">
+            <tag name="knp_menu.voter" />
+        </service>
+
         <service id="knp_menu.voter.router" class="Knp\Menu\Matcher\Voter\RouteVoter">
             <argument type="service" id="request_stack" />
             <tag name="knp_menu.voter" />


### PR DESCRIPTION
KnpMenu 3.5.0 introduced a CallbackVoter allowing items to define a `match_callback` extra to provide custom matching logic on a specific item.