### PR TITLE
Allow disabling the default RouteVoter via configuration

### DIFF
--- a/config/schema/menu-1.0.xsd
+++ b/config/schema/menu-1.0.xsd
@@ -14,6 +14,7 @@
         </xsd:all>
 
         <xsd:attribute name="templating" type="xsd:boolean" default="false"/>
+        <xsd:attribute name="route-voter" type="xsd:boolean" default="true"/>
         <xsd:attribute name="default-renderer" type="xsd:string" default="twig"/>
     </xsd:complexType>
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,6 +66,8 @@ You can define these options if you need to change them:
             # if true, enables the helper for PHP templates
             # support for templating is deprecated, it will be removed in next major version
             templating: false
+            # set to false to not register the default RouteVoter
+            route_voter: true
             # the renderer to use, list is also available by default
             default_renderer: twig
 
@@ -78,10 +80,12 @@ You can define these options if you need to change them:
 
             <!--
                 templating:       if true, enable the helper for PHP templates (deprecated)
+                route-voter:      set to false to not register the default RouteVoter
                 default-renderer: the renderer to use, list is also available by default
             -->
             <knp-menu:config
                 templating="false"
+                route-voter="true"
                 default-renderer="twig"
             >
                 <!-- add enabled="false" to disable the Twig extension and the TwigRenderer -->
@@ -99,6 +103,8 @@ You can define these options if you need to change them:
             ],
             // if true, enable the helper for PHP templates (deprecated)
             'templating' => false,
+            // set to false to not register the default RouteVoter
+            'route_voter' => true,
             // the renderer to use, list is also available by default
             'default_renderer' => 'twig',
         ]);

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -37,6 +37,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->booleanNode('templating')->defaultFalse()->end()
+                ->booleanNode('route_voter')->defaultTrue()->end()
                 ->scalarNode('default_renderer')->cannotBeEmpty()->defaultValue('twig')->end()
             ->end();
 

--- a/src/DependencyInjection/KnpMenuExtension.php
+++ b/src/DependencyInjection/KnpMenuExtension.php
@@ -38,6 +38,10 @@ class KnpMenuExtension extends Extension implements PrependExtensionInterface
             $loader->load('templating.php');
         }
 
+        if (!$config['route_voter']) {
+            $container->removeDefinition('knp_menu.voter.router');
+        }
+
         $container->setParameter('knp_menu.default_renderer', $config['default_renderer']);
 
         $container->registerForAutoconfiguration(VoterInterface::class)

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -30,7 +30,7 @@ class ConfigurationTest extends TestCase
         return [
             ['<config xmlns="http://knplabs.com/schema/dic/menu"/>'],
             [<<<EOC
-<config xmlns="http://knplabs.com/schema/dic/menu" templating="true" default-renderer="templating">
+<config xmlns="http://knplabs.com/schema/dic/menu" templating="true" route-voter="false" default-renderer="templating">
     <providers builder-alias="false" container-aware="false" builder-service="false"/>
     <twig template="custom.html.twig"/>
 </config>

--- a/tests/DependencyInjection/KnpMenuExtensionTest.php
+++ b/tests/DependencyInjection/KnpMenuExtensionTest.php
@@ -19,6 +19,15 @@ class KnpMenuExtensionTest extends TestCase
         $this->assertEquals('@KnpMenu/menu.html.twig', $container->getParameter('knp_menu.renderer.twig.template'));
         $this->assertFalse($container->hasDefinition('knp_menu.templating.helper'), 'The PHP helper is not loaded');
         $this->assertTrue($container->getDefinition('knp_menu.menu_provider.builder_alias')->hasTag('knp_menu.provider'), 'The BuilderAliasProvider is enabled');
+        $this->assertTrue($container->hasDefinition('knp_menu.voter.router'), 'The default RouteVoter is registered');
+    }
+
+    public function testDisableRouteVoter(): void
+    {
+        $container = new ContainerBuilder();
+        $loader = new KnpMenuExtension();
+        $loader->load([['route_voter' => false]], $container);
+        $this->assertFalse($container->hasDefinition('knp_menu.voter.router'), 'The default RouteVoter is not registered');
     }
 
     public function testEnableTwig(): void


### PR DESCRIPTION
Fix #382

Registering the built-in `RouteVoter` is currently unconditional. Applications that supply their own performance-optimized voter still pay for it: the default `RouteVoter` is called for every menu item whenever a custom voter returns `null` (because it cannot decide).

This adds a `route_voter` boolean option (default `true`, so behavior is unchanged) that lets you stop the bundle from registering the default `RouteVoter`:

```yaml
knp_menu:
    route_voter: false
```

When `false`, the `knp_menu.voter.router` service definition is removed.

Docs (`docs/index.rst` config reference, all three formats) and the XSD schema were updated in the same change.

## Test verification (RED → GREEN)

New tests: `KnpMenuExtensionTest::testDisableRouteVoter` (+ default now asserts the voter is registered) and the XSD `ConfigurationTest` case now carries `route-voter`.

RED — on unmodified `master` (production change reverted, new tests only):

```
1) ...KnpMenuExtensionTest::testDisableRouteVoter
Symfony\Component\Config\Definition\Exception\InvalidConfigurationException:
Unrecognized option "route_voter" under "knp_menu".

2) ...ConfigurationTest::testConfigurationMatchesXsd#1
Line 1: attribute 'route-voter': The attribute 'route-voter' is not allowed.

Tests: 4, Assertions: 8, Errors: 1, Failures: 1.
```

GREEN — with the fix:

```
OK, but there were issues!
Tests: 36, Assertions: 76, PHPUnit Notices: 15, Skipped: 1.
```

Baseline `master` is `Tests: 35` with the same 15 notices / 1 skipped — this PR adds one test and introduces no new failures. `composer validate --strict` and PHP-CS-Fixer (`--dry-run`) are both clean.